### PR TITLE
Adding timeout when fetching plugin & more clear plugin error message

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -110,6 +110,29 @@ func (h *BufPane) PluginCmd(args []string) {
 		return
 	}
 
+	switch args[0] {
+	case "install":
+		InfoBar.Message("Downloading plugin, please wait...")
+	case "remove":
+	case "update":
+		InfoBar.Message("Updating plugins, please wait...")
+	case "available":
+		InfoBar.Message("Fetching plugins, please wait...")
+	case "list":
+	case "search":
+		InfoBar.Message("Fetching plugins, please wait...")
+	default:
+		InfoBar.Error("Invalid plugin command:", args[0])
+	}
+
+	// NOTE: Display the message in info bar immediately before we get hang in PluginCommand()
+	// 		 Ideally we should lock it but it seems like main func in micro.go is constantly locking it
+	// 		 Locking it here will cause a deadlock
+	// screen.Lock()
+	InfoBar.Display()
+	screen.Show()
+	// screen.Unlock()
+
 	if h.Buf.Type != buffer.BTLog {
 		h.OpenLogBuf()
 	}

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -130,7 +130,7 @@ func (pc PluginChannels) Fetch(out io.Writer) PluginPackages {
 
 // Fetch retrieves all available PluginPackages from the given channel
 func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
-	client := http.Client {
+	client := http.Client{
 		Timeout: 30 * time.Second,
 	}
 	resp, err := client.Get(string(pc))
@@ -153,7 +153,7 @@ func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
 
 // Fetch retrieves all available PluginPackages from the given repository
 func (pr PluginRepository) Fetch(out io.Writer) PluginPackages {
-	client := http.Client {
+	client := http.Client{
 		Timeout: 30 * time.Second,
 	}
 	resp, err := client.Get(string(pr))
@@ -412,7 +412,7 @@ func GetInstalledPluginVersion(name string) string {
 // DownloadAndInstall downloads and installs the given plugin and version
 func (pv *PluginVersion) DownloadAndInstall(out io.Writer) error {
 	fmt.Fprintf(out, "Downloading %q (%s) from %q\n", pv.pack.Name, pv.Version, pv.Url)
-	client := http.Client {
+	client := http.Client{
 		Timeout: 30 * time.Second,
 	}
 	resp, err := client.Get(pv.Url)
@@ -664,6 +664,7 @@ func UpdatePlugins(out io.Writer, plugins []string) {
 func PluginCommand(out io.Writer, cmd string, args []string) {
 	switch cmd {
 	case "install":
+		fmt.Fprintln(out, "Downloading plugin, please wait...")
 		installedVersions := GetInstalledVersions(false)
 		for _, plugin := range args {
 			pp := GetAllPluginPackages(out).Get(plugin)
@@ -712,6 +713,7 @@ func PluginCommand(out io.Writer, cmd string, args []string) {
 			fmt.Fprintln(out, "No plugins removed")
 		}
 	case "update":
+		fmt.Fprintln(out, "Updating plugins, please wait...")
 		UpdatePlugins(out, args)
 	case "list":
 		plugins := GetInstalledVersions(false)
@@ -726,6 +728,7 @@ func PluginCommand(out io.Writer, cmd string, args []string) {
 			}
 		}
 	case "search":
+		fmt.Fprintln(out, "Fetching plugins, please wait...")
 		plugins := SearchPlugin(out, args)
 		fmt.Fprintln(out, len(plugins), "plugins found")
 		for _, p := range plugins {
@@ -734,6 +737,7 @@ func PluginCommand(out io.Writer, cmd string, args []string) {
 		}
 		fmt.Fprintln(out, "----------------")
 	case "available":
+		fmt.Fprintln(out, "Fetching plugins, please wait...")
 		packages := GetAllPluginPackages(out)
 		fmt.Fprintln(out, "Available Plugins:")
 		for _, pkg := range packages {

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/micro-editor/json5"
@@ -129,7 +130,10 @@ func (pc PluginChannels) Fetch(out io.Writer) PluginPackages {
 
 // Fetch retrieves all available PluginPackages from the given channel
 func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
-	resp, err := http.Get(string(pc))
+	client := http.Client {
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(string(pc))
 	if err != nil {
 		fmt.Fprintln(out, "Failed to query plugin channel:\n", err)
 		return nil
@@ -149,7 +153,10 @@ func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
 
 // Fetch retrieves all available PluginPackages from the given repository
 func (pr PluginRepository) Fetch(out io.Writer) PluginPackages {
-	resp, err := http.Get(string(pr))
+	client := http.Client {
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(string(pr))
 	if err != nil {
 		fmt.Fprintln(out, "Failed to query plugin repository:\n", err)
 		return nil
@@ -405,7 +412,10 @@ func GetInstalledPluginVersion(name string) string {
 // DownloadAndInstall downloads and installs the given plugin and version
 func (pv *PluginVersion) DownloadAndInstall(out io.Writer) error {
 	fmt.Fprintf(out, "Downloading %q (%s) from %q\n", pv.pack.Name, pv.Version, pv.Url)
-	resp, err := http.Get(pv.Url)
+	client := http.Client {
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(pv.Url)
 	if err != nil {
 		return err
 	}

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -152,6 +152,9 @@ func UnregisterRawSeq(r string) {
 	if Screen != nil {
 		Screen.UnregisterRawSeq(r)
 	}
+
+func Show() {
+	Screen.Show()
 }
 
 // TempFini shuts the screen down temporarily


### PR DESCRIPTION
Currently the `http.Get()` can hang for a long time, which also has no user feedback when doing something like `micro -plugin available`

Adding a timeout can tell the user which repo/channel is taking a long time, hence be able to inform the maintainer or troubleshoot it.

Also changed the error message for plugins to tell which part has failed to parse, which makes it easier to troubleshoot as well