### PR TITLE
Add syntax highlighting rules for .properties files

### DIFF
--- a/runtime/syntax/properties.yaml
+++ b/runtime/syntax/properties.yaml
@@ -1,0 +1,27 @@
+filetype: properties
+
+detect:
+    filename: "\\.properties$"
+
+rules:
+    # Key (Identifier) - Matches everything before the first = or :
+    - identifier: "^[[:space:]]*[^=:[:space:]]+"
+
+    # Assignment operators
+    - statement: "[=:]"
+
+    # Boolean constants
+    - constant: "\\b(true|false|TRUE|FALSE|yes|no|ON|OFF)\\b"
+
+    # Strings/Values (Simple match for text after assignment)
+    - constant.string: "([=:][[:space:]]*).*$"
+
+    # Comments - Properties files support both # and !
+    - comment:
+        start: "[#!]"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"
+
+    # Special characters like escaped spaces or newlines
+    - constant.specialChar: "\\\\([ tnfr'\"\\\\]|u[0-9a-fA-F]{4})"

--- a/runtime/syntax/properties.yaml
+++ b/runtime/syntax/properties.yaml
@@ -11,7 +11,8 @@ rules:
     - statement: "[=:]"
 
     # Boolean constants
-    - constant: "\\b(true|false|TRUE|FALSE|yes|no|ON|OFF)\\b"
+    - constant.bool.true: "\\b(true|TRUE|yes|ON)\\b"
+    - constant.bool.false: "\\b(false|FALSE|no|OFF)\\b"
 
     # Strings/Values (Simple match for text after assignment)
     - constant.string: "([=:][[:space:]]*).*$"
@@ -24,4 +25,4 @@ rules:
             - todo: "(TODO|XXX|FIXME):?"
 
     # Special characters like escaped spaces or newlines
-    - constant.specialChar: "\\\\([ tnfr'\"\\\\]|u[0-9a-fA-F]{4})"
+    - constant.specialChar: "\\\\([ :=tnfr'\"\\\\]|u[0-9a-fA-F]{4})"


### PR DESCRIPTION
This PR adds native support for the `.properties` format, a standard for Java, Spring, and infrastructure tools like Apache Kafka.

**Why this is needed:**
Without out-of-the-box support, users often assume Micro is incompatible with their configuration files when they see plain, uncolored text. These files are typically filled with dense comments; without highlighting, it is difficult to distinguish active settings from documentation, leading to configuration errors.

**Benefits:**

* **Visual Clarity:** Clearly separates keys, values, and comments.
* **User Retention:** Provides a "works-out-of-the-box" experience for developers.
* **Tested:** Verified for accuracy using production-grade Kafka configurations.

---

The code
```yaml
filetype: properties

detect:
    filename: "\\.properties$"

rules:
    # Key (Identifier) - Matches everything before the first = or :
    - identifier: "^[[:space:]]*[^=:[:space:]]+"

    # Assignment operators
    - statement: "[=:]"

    # Boolean constants
    - constant.bool.true: "\\b(true|TRUE|yes|ON)\\b"
    - constant.bool.false: "\\b(false|FALSE|no|OFF)\\b"

    # Strings/Values (Simple match for text after assignment)
    - constant.string: "([=:][[:space:]]*).*$"

    # Comments - Properties files support both # and !
    - comment:
        start: "[#!]"
        end: "$"
        rules:
            - todo: "(TODO|XXX|FIXME):?"

    # Special characters like escaped spaces or newlines
    - constant.specialChar: "\\\\([ :=tnfr'\"\\\\]|u[0-9a-fA-F]{4})"
```


## Without `properties` support:
<img width="1054" height="662" alt="image" src="https://github.com/user-attachments/assets/47e02b77-2f1a-4eed-9a36-24863992a2c4" />


## With `properties` support:
<img width="1096" height="647" alt="image" src="https://github.com/user-attachments/assets/884c6c15-494c-4c22-86dc-5ff014e0e7bf" />



## Temporary workaround:
Run this bash command
```bash
mkdir -p ~/.config/micro/syntax && cat <<'EOF' > ~/.config/micro/syntax/properties.yaml
filetype: properties

detect:
    filename: "\\.properties$"

rules:
    # Key (Identifier) - Matches everything before the first = or :
    - identifier: "^[[:space:]]*[^=:[:space:]]+"

    # Assignment operators
    - statement: "[=:]"

    # Boolean constants
    - constant.bool.true: "\\b(true|TRUE|yes|ON)\\b"
    - constant.bool.false: "\\b(false|FALSE|no|OFF)\\b"

    # Strings/Values (Simple match for text after assignment)
    - constant.string: "([=:][[:space:]]*).*$"

    # Comments - Properties files support both # and !
    - comment:
        start: "[#!]"
        end: "$"
        rules:
            - todo: "(TODO|XXX|FIXME):?"

    # Special characters like escaped spaces or newlines
    - constant.specialChar: "\\\\([ :=tnfr'\"\\\\]|u[0-9a-fA-F]{4})"
EOF
```