### PR TITLE
Fixing missing case for handling root node for splitting

### DIFF
--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -483,7 +483,20 @@ func (n *Node) Unsplit() bool {
 // flattens the tree by removing unnecessary intermediate parents that have only one child
 // and handles the side effect of it
 func (n *Node) flatten() {
-	if n.parent == nil || len(n.children) != 1 {
+	if len(n.children) != 1 {
+		return
+	}
+
+	// Special case for root node
+	if n.parent == nil {
+		*n = *n.children[0]
+		n.parent = nil
+		for _, c := range n.children {
+			c.parent = n
+		}
+		if len(n.children) == 0 {
+			n.Kind = STUndef
+		}
 		return
 	}
 

--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -413,7 +413,7 @@ func (n *Node) HSplit(bottom bool) uint64 {
 	if !n.IsLeaf() {
 		return 0
 	}
-	if n.Kind == STUndef {
+	if n.parent == nil {
 		n.Kind = STVert
 	}
 	if n.Kind == STVert {
@@ -429,13 +429,13 @@ func (n *Node) VSplit(right bool) uint64 {
 	if !n.IsLeaf() {
 		return 0
 	}
-	if n.Kind == STUndef {
+	if n.parent == nil {
 		n.Kind = STHoriz
 	}
-	if n.Kind == STVert {
-		return n.vVSplit(right)
+	if n.Kind == STHoriz {
+		return n.hVSplit(0, right)
 	}
-	return n.hVSplit(0, right)
+	return n.vVSplit(right)
 }
 
 // unsplits the child of a split
@@ -531,11 +531,19 @@ func (n *Node) flatten() {
 func (n *Node) String() string {
 	var strf func(n *Node, ident int) string
 	strf = func(n *Node, ident int) string {
-		marker := "|"
+		marker := ""
 		if n.Kind == STHoriz {
 			marker = "-"
+		} else if n.Kind == STVert {
+			marker = "|"
 		}
-		str := fmt.Sprint(strings.Repeat("\t", ident), marker, n.View, n.id)
+
+		var parentId uint64 = 0
+		if n.parent != nil {
+			parentId = n.parent.id
+		}
+
+		str := fmt.Sprint(strings.Repeat("\t", ident), marker, n.View, n.id, parentId)
 		if n.IsLeaf() {
 			str += "🍁"
 		}


### PR DESCRIPTION
At the beginning, the node tree looks like this, where x = `STUndef`
```
// <STUndef> <Coords> <ID> <Parent>
Node Tree:
 x{0 0 211 46} 1 root🍁
```

When performing VSplit or HSplit at the beginning, we check if we are root node using `STUndef`, in which we will always put the new split as its children, then we set the node kind for the root node. Which then looks like this:
```
Node Tree:
 -{0 0 211 46} 1 root
	|{0 0 105 46} 1 1🍁
	|{105 0 106 46} 2 1🍁
```

Since we have set root node kind after the initial split, the special handling for the root node using `STUndef` will no longer be valid. 

When using quit instead of unsplit, you can only get to the following node tree, and doing quit on the child will quit micro entirely.
```
Node Tree:
 -{0 0 211 46} 1 root
	|{0 0 211 46} 1 1🍁
```

However, if you are using unsplit, you can actually go back to the original state, like this:
One pane left:
```
Node Tree:
 -{0 0 211 46} 1 root
	|{0 0 211 46} 1 1🍁
```

After unsplit:
```
Node Tree:
 -{0 0 211 46} 1 root🍁
```

The fix is simply check if the parent is `nil` to determine if we are the root node or not.

I have also rearrange `VSplit` last if condition to match `HSplit` where we are treating current node as non-leaf node and add the new split to it's children.

Also updated the `String()` to show the parent node id for easier debugging.

Fixes #3980