### PR TITLE
fix: restore SetGlobalOption writeToFile for plugins

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -683,12 +683,12 @@ func SetGlobalOption(option, value string, writeToFile bool) error {
 	return SetGlobalOptionNative(option, nativeValue, writeToFile)
 }
 
-func SetGlobalOptionNativePlug(option string, nativeValue any) error {
-	return SetGlobalOptionNative(option, nativeValue, false)
+func SetGlobalOptionNativePlug(option string, nativeValue any, writeToFile bool) error {
+	return SetGlobalOptionNative(option, nativeValue, writeToFile)
 }
 
-func SetGlobalOptionPlug(option, value string) error {
-	return SetGlobalOption(option, value, false)
+func SetGlobalOptionPlug(option, value string, writeToFile bool) error {
+	return SetGlobalOption(option, value, writeToFile)
 }
 
 // ResetCmd resets a setting to its default value

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -224,15 +224,17 @@ The packages and their contents are listed below (in Go type signatures):
     - `GetGlobalOption(name string) any`: returns the value of a
        given plugin in the `GlobalSettings` map.
 
-    - `SetGlobalOption(option, value string) error`: sets an option to a
-       given value. This will try to convert the value into the proper
-       type for the option. Can return an error if the option name is not
-       valid, or the value can not be converted.
+    - `SetGlobalOption(option, value string, writeToFile bool) error`: sets
+       an option to a given value. This will try to convert the value into the
+       proper type for the option. If `writeToFile` is `true`, the setting will
+       be persisted to `settings.json`. Can return an error if the option name
+       is not valid, or the value can not be converted.
 
-    - `SetGlobalOptionNative(option string, value any) error`: sets
-       an option to a given value, where the type of value is the actual
-       type of the value internally. Can return an error if the provided value
-       is not valid for the given option.
+    - `SetGlobalOptionNative(option string, value any, writeToFile bool) error`:
+       sets an option to a given value, where the type of value is the actual
+       type of the value internally. If `writeToFile` is `true`, the setting
+       will be persisted to `settings.json`. Can return an error if the
+       provided value is not valid for the given option.
 
     - `ConfigDir`: the path to micro's currently active config directory.
 


### PR DESCRIPTION
After PR #3618, `SetGlobalOptionPlug` and `SetGlobalOptionNativePlug` hardcoded `writeToFile=false`, preventing plugins from persisting settings to `settings.json`.

This change makes both Plug functions accept a `writeToFile` bool parameter, giving plugins full control over whether settings are written to file. Plugins that don't pass writeToFile or pass false retain the safe non-persisting behavior introduced in #3618.

Fixes micro-editor/micro#4041