### PR TITLE
Duplicate line: preserve cursor position

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1442,12 +1442,11 @@ func (h *BufPane) Duplicate() bool {
 // DuplicateLine duplicates the current line. If there is a selection, DuplicateLine
 // duplicates all the lines that are (fully or partially) in the selection.
 func (h *BufPane) DuplicateLine() bool {
+	origLoc := h.Cursor.Loc
+	origLastVisualX := h.Cursor.LastVisualX
+	origLastWrappedVisualX := h.Cursor.LastWrappedVisualX
+	origSelection := h.Cursor.CurSelection
 	if h.Cursor.HasSelection() {
-		origLoc := h.Cursor.Loc
-		origLastVisualX := h.Cursor.LastVisualX
-		origLastWrappedVisualX := h.Cursor.LastWrappedVisualX
-		origSelection := h.Cursor.CurSelection
-
 		start := h.Cursor.CurSelection[0]
 		end := h.Cursor.CurSelection[1]
 		if start.GreaterThan(end) {
@@ -1456,19 +1455,12 @@ func (h *BufPane) DuplicateLine() bool {
 		if end.X == 0 {
 			end = end.Move(-1, h.Buf)
 		}
-
 		h.Cursor.Deselect(true)
 		h.Cursor.Loc = end
 		h.Cursor.End()
 		for y := start.Y; y <= end.Y; y++ {
 			h.Buf.Insert(h.Cursor.Loc, "\n"+string(h.Buf.LineBytes(y)))
 		}
-
-		h.Cursor.Loc = origLoc
-		h.Cursor.LastVisualX = origLastVisualX
-		h.Cursor.LastWrappedVisualX = origLastWrappedVisualX
-		h.Cursor.CurSelection = origSelection
-
 		if start.Y < end.Y {
 			InfoBar.Message(fmt.Sprintf("Duplicated %d lines", end.Y-start.Y+1))
 		} else {
@@ -1479,6 +1471,10 @@ func (h *BufPane) DuplicateLine() bool {
 		h.Buf.Insert(h.Cursor.Loc, "\n"+string(h.Buf.LineBytes(h.Cursor.Y)))
 		InfoBar.Message("Duplicated line")
 	}
+	h.Cursor.Loc = origLoc
+	h.Cursor.LastVisualX = origLastVisualX
+	h.Cursor.LastWrappedVisualX = origLastWrappedVisualX
+	h.Cursor.CurSelection = origSelection
 	h.Relocate()
 	return true
 }


### PR DESCRIPTION
This PR changes the behavior of `DuplicateLine` command (`Ctrl-d`).
The cursor position now remains in its original place, allowing you to avoid losing input focus.
This is implemented in a similar way in some other text editors, ex. VSCode, Notepad++.