### PR TITLE
Make missing plugin repo errors more informative

### DIFF
--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -155,12 +155,22 @@ func (pr PluginRepository) Fetch(out io.Writer) PluginPackages {
 		return PluginPackages{}
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(out, "Skipped: %s\n", pr)
+		fmt.Fprintf(out, " Reason: Server error %d (%s)\n", resp.StatusCode,
+			http.StatusText(resp.StatusCode))
+		return nil
+	}
+
 	decoder := json5.NewDecoder(resp.Body)
 
 	var plugins PluginPackages
 	if err := decoder.Decode(&plugins); err != nil {
-		fmt.Fprintln(out, "Failed to decode repository data:\n", err)
-		return PluginPackages{}
+		fmt.Fprintf(out, "Skipped: %s\n", pr)
+		fmt.Fprintf(out, " Reason: Failed to decode repository data:\n")
+		fmt.Fprintf(out, " %s\n", err)
+		return nil
 	}
 	if len(plugins) > 0 {
 		return PluginPackages{plugins[0]}

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -132,7 +132,7 @@ func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
 	resp, err := http.Get(string(pc))
 	if err != nil {
 		fmt.Fprintln(out, "Failed to query plugin channel:\n", err)
-		return PluginPackages{}
+		return nil
 	}
 	defer resp.Body.Close()
 	decoder := json5.NewDecoder(resp.Body)
@@ -140,7 +140,7 @@ func (pc PluginChannel) Fetch(out io.Writer) PluginPackages {
 	var repositories []PluginRepository
 	if err := decoder.Decode(&repositories); err != nil {
 		fmt.Fprintln(out, "Failed to decode channel data:\n", err)
-		return PluginPackages{}
+		return nil
 	}
 	return fetchAllSources(len(repositories), func(i int) PluginPackages {
 		return repositories[i].Fetch(out)
@@ -152,7 +152,7 @@ func (pr PluginRepository) Fetch(out io.Writer) PluginPackages {
 	resp, err := http.Get(string(pr))
 	if err != nil {
 		fmt.Fprintln(out, "Failed to query plugin repository:\n", err)
-		return PluginPackages{}
+		return nil
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Thank you for this great editor!
Please consider this update to handle missing plugin repo errors better.
It addresses #1276 

Plugins in official channel are ok now (may change someday), but 3 plugins of [unofficial channel](https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/main/channel.json) are missing and it shows up as strange messages while running `micro  -plugin available` or other plugin commands:

```
Failed to decode repository data:
 json: cannot unmarshal number into Go value of type config.PluginPackages
Failed to decode repository data:
 invalid character '<' looking for beginning of value
Failed to decode repository data:
 invalid character '<' looking for beginning of value
```

Instead it would show up like this:

```
Skipped: Plugin repository not found at https://raw.githubusercontent.com/cadnza/mxc/main/repo.json (Status Code: 404).
Skipped: Plugin repository not found at https://notabug.org/dustdfg/micro-calc/raw/master/repo.json (Status Code: 404).
Skipped: Plugin repository not found at https://notabug.org/dustdfg/micro-mdtree/raw/master/repo.json (Status Code: 404).
```