### PR TITLE
Add copypaste to the help documentation list of help sections

### DIFF
--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -51,8 +51,8 @@ Here are the available help topics:
    plugins
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
-* `copypaste`: Explains micro's copy and paste usage and configuration. It 
-   describes how copy and paste is working on different operating systems and 
+* `copypaste`: Explains micro's copy and paste usage and configuration.
+   It describes how copy and paste is working on different operating systems and
    setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -51,6 +51,8 @@ Here are the available help topics:
    plugins
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
+* `copypaster`: Explains micro's copy and paste usage and configuration and how it
+   is working on different operating systems and setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.
 

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -51,8 +51,9 @@ Here are the available help topics:
    plugins
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
-* `copypaste`: Explains micro's copy and paste usage and configuration. It describes how copy and pasting
-   is working on different operating systems and setups.
+* `copypaste`: Explains micro's copy and paste usage and configuration. It 
+   describes how copy and pasting is working on different operating systems and 
+   setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.
 

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -51,7 +51,7 @@ Here are the available help topics:
    plugins
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
-* `copypaster`: Explains micro's copy and paste usage and configuration and how it
+* `copypaste`: Explains micro's copy and paste usage and configuration and how it
    is working on different operating systems and setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -52,7 +52,7 @@ Here are the available help topics:
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
 * `copypaste`: Explains micro's copy and paste usage and configuration. It 
-   describes how copy and pasting is working on different operating systems and 
+   describes how copy and paste is working on different operating systems and 
    setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -51,7 +51,7 @@ Here are the available help topics:
    plugins
 * `colors`: Explains micro's colorscheme and syntax highlighting engine and how
    to create your own colorschemes or add new languages to the engine
-* `copypaste`: Explains micro's copy and paste usage and configuration and how it
+* `copypaste`: Explains micro's copy and paste usage and configuration. It describes how copy and pasting
    is working on different operating systems and setups.
 
 For example, to open the help page on plugins you would run `> help plugins`.


### PR DESCRIPTION
In the list that display all the sections of the help of micro, the copypaste section was missing.

This PR fixes this.

Regards, Antoine