### PR TITLE
syntax: remove nonexistent nushell comment syntax

### DIFF
--- a/runtime/syntax/nu.yaml
+++ b/runtime/syntax/nu.yaml
@@ -94,10 +94,6 @@ rules:
     - comment:
         start: "#"
         end: "$"
-        rules: []
-    - comment:
-        start: "/\\*"
-        end: "\\*/"
         rules:
             - todo: "(FIXME|TODO|NOTE):?"
     - constant.string:


### PR DESCRIPTION
fixes #4101