### PR TITLE
Enabled syntax highlighting on jsonc and josn5

### DIFF
--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -1,7 +1,7 @@
 filetype: json
 
 detect:
-    filename: "\\.json$"
+    filename: "\\.json(c|5)?$"
     header: "^\\{$"
 
 rules:


### PR DESCRIPTION
The default json.yaml already allows for comments, but for whatever reason the .jsonc and .json5 extensions weren't associated with it.