### PR TITLE
fix: parse plugin repo metadata as JSON5

### DIFF
--- a/internal/config/plugin_manager.go
+++ b/internal/config/plugin_manager.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
+
+	"github.com/micro-editor/json5"
 )
 
 var (
@@ -35,10 +35,7 @@ type PluginInfo struct {
 func NewPluginInfo(data []byte) (*PluginInfo, error) {
 	var info []PluginInfo
 
-	dec := json.NewDecoder(bytes.NewReader(data))
-	// dec.DisallowUnknownFields() // Force errors
-
-	if err := dec.Decode(&info); err != nil {
+	if err := json5.Unmarshal(data, &info); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/plugin_manager_test.go
+++ b/internal/config/plugin_manager_test.go
@@ -1,0 +1,23 @@
+package config
+
+import "testing"
+
+func TestNewPluginInfoAllowsJSON5Comments(t *testing.T) {
+	data := []byte(`[
+  // repo.json files are decoded as JSON5 by the plugin installer.
+  {
+    "Name": "example",
+    "Description": "Example plugin",
+    "Website": "https://example.com"
+  }
+]`)
+
+	info, err := NewPluginInfo(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Name != "example" {
+		t.Fatalf("expected plugin name %q, got %q", "example", info.Name)
+	}
+}


### PR DESCRIPTION
Fixes #4084.

## Summary
- Decode installed plugin `repo.json` metadata with `json5`, matching the plugin installer and channel/repository decoding paths.
- Add a regression test covering a `repo.json` payload with a JSON5 comment.

## Tests
- Red before fix: `go test ./internal/config -run TestNewPluginInfoAllowsJSON5Comments -count=1` failed with `invalid character '/' looking for beginning of value`
- `go test ./internal/config -run TestNewPluginInfoAllowsJSON5Comments -count=1`
- `go test ./internal/config -count=1`
- `go test ./...`
- `git diff --check`
