### PR TITLE
Add `tabalways` option to always show tab bar

### DIFF
--- a/data/micro.json
+++ b/data/micro.json
@@ -322,6 +322,11 @@
             "type": "boolean",
             "default": true
         },
+        "tabalways": {
+            "description": "Whether to always show the tab bar, even when only one tab is open\nhttps://github.com/micro-editor/micro/blob/master/runtime/help/options.md#options",
+            "type": "boolean",
+            "default": false
+        },
         "tabmovement": {
             "description": "Whether to navigate spaces at the beginning of lines as if they are tabs\nhttps://github.com/micro-editor/micro/blob/master/runtime/help/options.md#options",
             "type": "boolean",

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -587,7 +587,7 @@ func doSetGlobalOptionNative(option string, nativeValue any) error {
 		for _, b := range buffer.OpenBuffers {
 			b.UpdateRules()
 		}
-	} else if option == "infobar" || option == "keymenu" {
+	} else if option == "infobar" || option == "keymenu" || option == "tabalways" {
 		Tabs.Resize()
 	} else if option == "mouse" {
 		if !nativeValue.(bool) {

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -26,7 +26,7 @@ func NewTabList(bufs []*buffer.Buffer) *TabList {
 	iOffset := config.GetInfoBarOffset()
 	tl := new(TabList)
 	tl.List = make([]*Tab, len(bufs))
-	if len(bufs) > 1 {
+	if tabBarVisible(len(bufs)) {
 		for i, b := range bufs {
 			tl.List[i] = NewTabFromBuffer(0, 1, w, h-1-iOffset, b)
 		}
@@ -75,15 +75,22 @@ func (t *TabList) RemoveTab(id uint64) {
 	}
 }
 
+// tabBarVisible reports whether the tab bar should be drawn. It is normally
+// only shown when more than one tab is open, but the tabalways option forces
+// it to always be visible
+func tabBarVisible(numTabs int) bool {
+	return numTabs > 1 || config.GetGlobalOption("tabalways").(bool)
+}
+
 // Resize resizes all elements within the tab list
-// One thing to note is that when there is only 1 tab
-// the tab bar should not be drawn so resizing must take
+// One thing to note is that when the tab bar is hidden (only 1 tab open and
+// tabalways off) the panes occupy the full height, so resizing must take
 // that into account
 func (t *TabList) Resize() {
 	w, h := screen.Screen.Size()
 	iOffset := config.GetInfoBarOffset()
 	InfoBar.Resize(w, h-1)
-	if len(t.List) > 1 {
+	if tabBarVisible(len(t.List)) {
 		for _, p := range t.List {
 			p.Y = 1
 			p.Node.Resize(w, h-1-iOffset)
@@ -107,7 +114,7 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 		mx, my := e.Position()
 		switch e.Buttons() {
 		case tcell.Button1:
-			if my == t.Y && len(t.List) > 1 {
+			if my == t.Y && tabBarVisible(len(t.List)) {
 				if mx == 0 {
 					t.Scroll(-4)
 				} else if mx == t.Width-1 {
@@ -127,12 +134,12 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 				return
 			}
 		case tcell.WheelUp:
-			if my == t.Y && len(t.List) > 1 {
+			if my == t.Y && tabBarVisible(len(t.List)) {
 				t.Scroll(4)
 				return
 			}
 		case tcell.WheelDown:
-			if my == t.Y && len(t.List) > 1 {
+			if my == t.Y && tabBarVisible(len(t.List)) {
 				t.Scroll(-4)
 				return
 			}
@@ -144,7 +151,7 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 // Display updates the names and then displays the tab bar
 func (t *TabList) Display() {
 	t.UpdateNames()
-	if len(t.List) > 1 {
+	if tabBarVisible(len(t.List)) {
 		t.TabWindow.Display()
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -129,6 +129,7 @@ var DefaultGlobalOnlySettings = map[string]any{
 	"savehistory":    true,
 	"scrollbarchar":  "|",
 	"sucmd":          "sudo",
+	"tabalways":      false,
 	"tabhighlight":   false,
 	"tabreverse":     true,
 	"xterm":          false,

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -462,6 +462,10 @@ Here are the available options:
 
     default value: `true`
 
+* `tabalways`: always shows the tab bar, even when only one tab is open.
+
+    default value: `false`
+
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
    colors with respect to the tab bar.
 
@@ -628,6 +632,7 @@ so that you can see what the formatting should look like.
     "statusline": true,
     "sucmd": "sudo",
     "syntax": true,
+    "tabalways": false,
     "tabhighlight": true,
     "tabmovement": false,
     "tabreverse": false,


### PR DESCRIPTION
This PR fixes #4017 and picks up where #3882 left off, which @dmaluka supported.

cc @dmaluka @1ynxy @dave-foxglove @JoeKar

<img width="1744" height="829" alt="micro" src="https://github.com/user-attachments/assets/f0fa3baf-c772-42d4-9c20-4140cbd641a8" />
