### PR TITLE
github/workflows: Bump actions to retire usage of `Node20`

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         cache: false
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: master
         fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
         message: "Pre-release nightly"
 
     - name: Publish
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         name: nightly
         tag_name: nightly

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         cache: false
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -28,7 +28,7 @@ jobs:
       run: tools/cross-compile.sh
 
     - name: Publish
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: binaries/*
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,12 +8,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         cache: false
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true


### PR DESCRIPTION
This follows the deprecation notice published under:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Actually all our actions (in GitLab called pipelines) work (except some GitHub server hick-ups), but they already throw a deprecation warning:
https://github.com/micro-editor/micro/actions/runs/27245759041

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-go@v5, softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. [...]

Without updating `actions/setup-go@v5` -> `v6`, `actions/checkout@v4` -> `v6` (min. `v5`) and `softprops/action-gh-release@v2` -> `v3` they may refuse to work from June 16th, 2026 onward. This affects the nightly builds, the test runs and potential releases.