### PR TITLE
docs/option g mac

### DIFF
--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -157,6 +158,9 @@ func (s *StatusLine) Display() {
 			binding := string(name[5:])
 			for k, v := range config.Bindings["buffer"] {
 				if v == binding {
+					if runtime.GOOS == "darwin" {
+						k = strings.Replace(k, "Alt", "Option", -1)
+					}
 					return []byte(k)
 				}
 			}

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -10,7 +10,7 @@ display. From now on, when the documentation shows a command to run (such as
 
 For a list of the default keybindings, run `> help defaultkeys`.
 For more information on keybindings, see `> help keybindings`.
-To toggle a short list of important keybindings, press Alt-g.
+To toggle a short list of important keybindings, press Alt-g (Option-g on Mac).
 
 ## Quick-start
 

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -593,7 +593,7 @@ conventions for text editing defaults.
     "ShiftPageUp":    "SelectPageUp",
     "ShiftPageDown":  "SelectPageDown",
     "Ctrl-g":         "ToggleHelp",
-    "Alt-g":          "ToggleKeyMenu",
+    "Alt-g":          "ToggleKeyMenu", (Option-g on Mac)
     "Ctrl-r":         "ToggleRuler",
     "Ctrl-l":         "command-edit:goto ",
     "Delete":         "Delete",

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -224,7 +224,7 @@ Here are the available options:
     default value: `false`
 
 * `keymenu`: display the nano-style key menu at the bottom of the screen. Note
-   that ToggleKeyMenu is bound to `Alt-g` by default and this is displayed in
+   that ToggleKeyMenu is bound to `Alt-g` (Option-g on Mac) by default and this is displayed in
    the statusline. To disable the key binding, bind `Alt-g` to `None`.
 
     default value: `false`


### PR DESCRIPTION
renamed alt+g for keybindings to option+g