### PR TITLE
buffer: Remove buffer invalidation in `CloseOpenBuffers()`

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -502,11 +502,14 @@ func NewBuffer(r io.Reader, size int64, path string, btype BufType, cmd Command)
 
 // CloseOpenBuffers removes all open buffers
 func CloseOpenBuffers() {
-	for i, buf := range OpenBuffers {
-		buf.Fini()
-		OpenBuffers[i] = nil
+	// use a copy, since we're gonna remove elements from OpenBuffers
+	// while iterating
+	buffers := make([]*Buffer, len(OpenBuffers))
+	copy(buffers, OpenBuffers)
+
+	for _, buf := range buffers {
+		buf.Close()
 	}
-	OpenBuffers = OpenBuffers[:0]
 }
 
 // Close removes this buffer from the list of open buffers


### PR DESCRIPTION
This resolves issue #4131, and a local copy is used to prevent the issue resolved by #2898 from recurring.

Fixes #4131