### PR TITLE
fix: scroll command-bar suggestions by display width so wide characters stay visible

### DIFF
--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -192,7 +192,7 @@ func (i *InfoWindow) scrollToSuggestion() {
 	s := i.totalSize()
 
 	for j, n := range i.Suggestions {
-		c := util.CharacterCountInString(n)
+		c := runewidth.StringWidth(n)
 		if j == i.CurSuggestion {
 			if x+c >= i.hscroll+i.Width {
 				i.hscroll = util.Clamp(x+c+1-i.Width, 0, s-i.Width)


### PR DESCRIPTION
The autocomplete suggestion strip in the info bar can scroll to the wrong offset when a suggestion contains full-width characters (CJK ideographs, kana, full-width forms), leaving the selected suggestion partly or fully off screen.

`scrollToSuggestion` tracks its column position with `util.CharacterCountInString`, which counts characters, so a CJK ideograph counts as 1. The strip itself is drawn by display width: `Display` advances by `runewidth.RuneWidth` per rune, and `totalSize` already sums `runewidth.StringWidth(n)`. Once a suggestion is wider than its character count, the scroll math and the renderer disagree.

Example: suggestions `["日本語テスト", "ok", "end"]` with the second one selected, in a 14-column strip. `日本語テスト` is 6 characters but 12 display columns, so the renderer draws `ok` at columns 13 to 15. `scrollToSuggestion` places it at column 7, keeps `hscroll` at 0, and `ok` is clipped at the right edge. Measuring by display width sets `hscroll` to 2 and `ok` is fully visible.

Switching that line to `runewidth.StringWidth(n)` matches `totalSize` and the renderer. ASCII-only suggestions are unchanged, since there character count equals display width.

I confirmed the package builds and the `internal/util` tests pass. `internal/display` has no test files, so I checked the scroll offset against the renderer's true columns for the case above: wrong before, correct after, and unchanged for ASCII input.
