### PR TITLE
Fixing resize split can cause crashes when node is root

### DIFF
--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -186,7 +186,7 @@ func (n *Node) hResizeSplit(i int, size int) bool {
 // ResizeSplit resizes a certain split to a given size
 func (n *Node) ResizeSplit(size int) bool {
 	// TODO: `size < 0` does not work for some reason
-	if size <= 0 {
+	if size <= 0 || n.parent == nil {
 		return false
 	}
 	if len(n.parent.children) <= 1 {


### PR DESCRIPTION
Fixing resize split can cause crashes when node is root.

"Regression" of #3983 where ResizeSplit() assumed that the root node always has a single child which aligns to the previous behavior.

Found this behavior when trying to resize a lone split like so:
```lua
tree_view:ResizePane(tree_width)
```

where `tree_view` is a lone pane and `ResizePane()` calls `n.ResizeSplit(size)`.
