### PR TITLE
Using file complete for the save command

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -45,7 +45,7 @@ func InitCommands() {
 		"quit":        {(*BufPane).QuitCmd, nil},
 		"goto":        {(*BufPane).GotoCmd, nil},
 		"jump":        {(*BufPane).JumpCmd, nil},
-		"save":        {(*BufPane).SaveCmd, nil},
+		"save":        {(*BufPane).SaveCmd, buffer.FileComplete},
 		"replace":     {(*BufPane).ReplaceCmd, nil},
 		"replaceall":  {(*BufPane).ReplaceAllCmd, nil},
 		"vsplit":      {(*BufPane).VSplitCmd, buffer.FileComplete},


### PR DESCRIPTION
Using file complete for the save command. 

This is useful when trying to save as a different file or simply auto complete the directories you want to save to