### PR TITLE
README: Remove retired Go Report Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img alt="micro logo" src="./assets/micro-logo-drop.svg" width="500px"/>
 
 ![Test Workflow](https://github.com/micro-editor/micro/actions/workflows/test.yaml/badge.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/micro-editor/micro/v2)](https://goreportcard.com/report/github.com/micro-editor/micro/v2)
 [![Release](https://img.shields.io/github/release/micro-editor/micro.svg?label=Release)](https://github.com/micro-editor/micro/releases)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/micro-editor/micro/blob/master/LICENSE)
 [![Join the chat at https://gitter.im/zyedidia/micro](https://badges.gitter.im/zyedidia/micro.svg)](https://gitter.im/zyedidia/micro?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
https://github.com/gojp/goreportcard was archived on 2026-07-01.
https://goreportcard.com/ and the badge link currently lead to a farewell message.