### PR TITLE
Fix highlighting crash when line index is outdated

### DIFF
--- a/internal/buffer/line_array.go
+++ b/internal/buffer/line_array.go
@@ -386,6 +386,13 @@ func (la *LineArray) SearchMatch(b *Buffer, pos Loc) bool {
 	}
 
 	lineN := pos.Y
+
+	// Prevent crash if the highlighting occurs during a line deletion,
+	// before the draw position is updated.
+	if lineN >= len(la.lines) {
+		return false
+	}
+
 	if la.lines[lineN].search == nil {
 		la.lines[lineN].search = make(map[*Buffer]*searchState)
 	}


### PR DESCRIPTION
A random crash happened to me:
```
Micro encountered an error: runtime.boundsError runtime error: index out of range [197] with length 197
runtime/panic.go:115 (0x55a67689b1f4)
github.com/zyedidia/micro/internal/buffer/line_array.go:394 (0x55a676cf4c32)
github.com/zyedidia/micro/internal/buffer/buffer.go:1423 (0x55a676d12c88)
github.com/zyedidia/micro/internal/display/bufwindow.go:494 (0x55a676d12c3f)
github.com/zyedidia/micro/internal/display/bufwindow.go:756 (0x55a676d11833)
github.com/zyedidia/micro/internal/display/bufwindow.go:827 (0x55a676d14319)
github.com/zyedidia/micro/cmd/micro/micro.go:413 (0x55a676d73db5)
github.com/zyedidia/micro/cmd/micro/micro.go:400 (0x55a676d73b30)
internal/runtime/atomic/types.go:194 (0x55a6768a053d)
runtime/asm_amd64.s:1700 (0x55a6768dc0c1)

If you can reproduce this error, please report it at https://github.com/zyedidia/micro/issues
```

Since I was using version 2.0.14-1+b6 from Debian, the problem is in this line: https://github.com/micro-editor/micro/blob/77de728b87a624f7cfef1a7db79ff383421780fe/internal/buffer/line_array.go#L389
(check https://sources.debian.org/src/micro/2.0.14-1/internal/buffer/line_array.go#L394)

I could not reproduce the bug, but it seems to me that the highlighter was trying to access a line that was just deleted,  using an outdated Y position of the window. So this proposed fix is simple, but the concurrent access problem can be deeper.