### PR TITLE
packaging: Add Russian translations for the desktop entry and metainfo

### DIFF
--- a/assets/packaging/micro.desktop
+++ b/assets/packaging/micro.desktop
@@ -2,12 +2,15 @@
 
 Name=Micro
 GenericName=Text Editor
+GenericName[ru]=Текстовый редактор
 Comment=Edit text files in a terminal
+Comment[ru]=Редактирование текстовых файлов в терминале
 
 Icon=micro
 Type=Application
 Categories=Utility;TextEditor;Development;
 Keywords=text;editor;syntax;terminal;
+Keywords[ru]=текст;текстовый;редактор;подсветка;синтаксис;терминал;консоль;
 
 Exec=micro %F
 StartupNotify=false

--- a/data/io.github.zyedidia.micro.metainfo.xml
+++ b/data/io.github.zyedidia.micro.metainfo.xml
@@ -4,6 +4,7 @@
 	<launchable type="desktop-id">micro.desktop</launchable>
 	<name>Micro Text Editor</name>
 	<summary>A modern and intuitive terminal-based text editor</summary>
+	<summary xml:lang="ru">Современный и понятный текстовый редактор для терминала</summary>
 	<description>
 		<p>
 			micro is a terminal-based text editor that aims to be easy to use and
@@ -11,11 +12,23 @@
 			It comes as a single, batteries-included, static binary with no dependencies;
 			you can download and use it right now!
 		</p>
+		<p xml:lang="ru">
+			Редактор micro работает в терминале и старается быть простым и понятным,
+			не отказываясь при этом от возможностей современных терминалов. Он поставляется
+			одним статическим исполняемым файлом без единой зависимости и со всем нужным
+			внутри: достаточно скачать — и можно работать.
+		</p>
 		<p>
 			As its name indicates, micro aims to be somewhat of a successor to the nano
 			editor by being easy to install and use. It strives to be enjoyable as a full-time
 			editor for people who prefer to work in a terminal, or those who regularly
 			edit files over SSH.
+		</p>
+		<p xml:lang="ru">
+			Как подсказывает название, micro задуман своего рода преемником редактора nano:
+			его так же легко поставить и так же просто освоить. Им должно быть приятно
+			пользоваться каждый день — и тем, кто предпочитает работать в терминале,
+			и тем, кто регулярно правит файлы по SSH.
 		</p>
 	</description>
 	<metadata_license>MIT</metadata_license>
@@ -39,6 +52,7 @@
 	<screenshots>
 		<screenshot type="default">
 			<caption>Micro Text Editor editing its source code</caption>
+			<caption xml:lang="ru">Редактор Micro за правкой собственного исходного кода</caption>
 			<image type="source">https://raw.githubusercontent.com/micro-editor/micro/master/assets/micro-solarized.png</image>
 		</screenshot>
 	</screenshots>


### PR DESCRIPTION
The desktop entry and the AppStream metainfo currently ship English only, so on a Russian system micro shows up in the application menu and in software centers like GNOME Software or KDE Discover with untranslated text. This adds Russian for the generic name, the comment and the keywords in `micro.desktop`, and for the summary, the description and the screenshot caption in the metainfo file. The name Micro is left alone, and nothing changes for anyone not running a Russian locale.

I tried it on Arch with KDE Plasma 6 under `ru_RU.UTF-8`: with the modified `micro.desktop` in `~/.local/share/applications` and the caches rebuilt, the menu entry reads "Редактирование текстовых файлов в терминале", while the very same file under an English locale still reads "Edit text files in a terminal". `desktop-file-validate` and `appstreamcli validate` say exactly what they said before the change, and passing the metainfo through `appstreamcli compose` and `convert` shows the Russian summary, description and keywords landing in the generated DEP-11 catalog that software centers actually read.

Happy to adjust the phrasing if you would rather have the description follow the English text more literally.
