### PR TITLE
Add .libsonnet file type to jsonnet syntax highlighting

### DIFF
--- a/runtime/syntax/jsonnet.yaml
+++ b/runtime/syntax/jsonnet.yaml
@@ -1,7 +1,7 @@
 filetype: jsonnet
 
 detect:
-    filename: "\\.jsonnet$"
+    filename: "\\.(jsonnet|libsonnet)$"
 
 # Spec: https://jsonnet.org/ref/spec.html
 


### PR DESCRIPTION
Adds `.libsonnet` file suffix as a matcher for jsonnet syntax highlighting profile. It's a commonly used convention, they even write about it on the [official website](https://jsonnet.org/learning/tutorial.html#imports).