### PR TITLE
test: Check `gofmt` results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Go tools like `gofmt` require LF as line endings
+*.go text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ testgen:
 test:
 	go test ./internal/...
 	go test ./cmd/...
+	@test -z "$$(gofmt -l .)" || { echo "gofmt issues:"; gofmt -d -e .; exit 1; }
 
 bench:
 	for i in 1 2 3; do \


### PR DESCRIPTION
We like to have gofmt-ed files present in PRs before a review is done. To reach this we let the PR test fail in the moment the files are not properly formatted.