### PR TITLE
util+buffer: Accept both path separators on Windows

### DIFF
--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -106,8 +107,16 @@ func FileComplete(b *Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
 	input, argstart := b.GetArg()
 
+	// Windows accepts both separators, so keep completing with the one that is
+	// already in use instead of mixing them
 	sep := string(os.PathSeparator)
-	dirs := strings.Split(input, sep)
+	if i := strings.LastIndexAny(input, "/"+sep); i >= 0 {
+		sep = input[i : i+1]
+	}
+
+	// and normalize the input before splitting it, otherwise a forward slash
+	// separated path is treated as a single name
+	dirs := strings.Split(filepath.ToSlash(input), "/")
 
 	var files []fs.DirEntry
 	var err error

--- a/internal/buffer/autocomplete_test.go
+++ b/internal/buffer/autocomplete_test.go
@@ -1,0 +1,38 @@
+package buffer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/micro-editor/micro/v2/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileComplete(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "foo.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if err := os.Mkdir(filepath.Join(dir, "bar"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	complete := func(input string) []string {
+		b := NewBufferFromString(input, "", BTDefault)
+		b.GetActiveCursor().X = util.CharacterCountInString(input)
+		_, suggestions := FileComplete(b)
+		return suggestions
+	}
+
+	// Both separators are valid on Windows, so completion has to work with
+	// either one of them and has to stay with the one already in use.
+	for _, sep := range []string{"/", string(os.PathSeparator)} {
+		prefix := "open " + filepath.ToSlash(dir) + sep
+
+		assert.Equal(t, []string{"foo.txt"}, complete(prefix+"fo"))
+		assert.Equal(t, []string{"bar" + sep}, complete(prefix+"ba"))
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -398,7 +398,7 @@ func ReplaceHome(path string) (string, error) {
 	var userData *user.User
 	var err error
 
-	homeString := strings.Split(path, "/")[0]
+	homeString := strings.Split(filepath.ToSlash(path), "/")[0]
 	if homeString == "~" {
 		userData, err = user.Current()
 		if err != nil {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os"
+	"os/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,30 @@ func TestStringWidth(t *testing.T) {
 
 	n := StringWidth(bytes, 23, 4)
 	assert.Equal(t, 26, n)
+}
+
+func TestReplaceHome(t *testing.T) {
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := usr.HomeDir
+
+	path, err := ReplaceHome("~")
+	assert.NoError(t, err)
+	assert.Equal(t, home, path)
+
+	// Both separators are valid on Windows, so `~` has to be recognized
+	// regardless of which one follows it.
+	for _, sep := range []string{"/", string(os.PathSeparator)} {
+		path, err = ReplaceHome("~" + sep + "foo.txt")
+		assert.NoError(t, err)
+		assert.Equal(t, home+sep+"foo.txt", path)
+	}
+
+	path, err = ReplaceHome("foo~bar")
+	assert.NoError(t, err)
+	assert.Equal(t, "foo~bar", path)
 }
 
 func TestSliceVisualEnd(t *testing.T) {


### PR DESCRIPTION
On Windows both `/` and `\` work as separators, but a couple of spots assume one. `ReplaceHome()` splits on `/` to find the end of the `~` component, so `~\foo.txt` turns into a user lookup for the whole string and fails with "Could not find user". `FileComplete()` splits on `os.PathSeparator` only, so a forward-slash path like `C:/Users/User/fo<Tab>` gives no suggestions at all.

Both now normalize with `filepath.ToSlash()`, and completion hands back whichever separator the input already uses, so `C:/Users/User/su` completes to `subdir/` rather than `subdir\`. No-ops on Unix, where `\` is an ordinary filename character. Tests cover both separators.

#3955 rewrites the same `ReplaceHome()` line but hardcodes `/` more firmly, so `~\foo.txt` still breaks there.

Fixes #3828
