### PR TITLE
plugin: linter: Use `filepath.Base()` to compare the linted file

### DIFF
--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -189,7 +189,7 @@ function onExit(output, args)
             elseif col == nil then
                 hascol = false
             end
-            if basename(buf.Path) == basename(file) then
+            if filepath.Base(buf.Path) == filepath.Base(file) then
                 local bmsg = nil
                 if hascol then
                     local mstart = buffer.Loc(tonumber(col-1+coff), tonumber(line-1+loff))
@@ -211,13 +211,4 @@ function split(str, sep)
         table.insert(result, each)
     end
     return result
-end
-
-function basename(file)
-    local sep = "/"
-    if runtime.GOOS == "windows" then
-        sep = "\\"
-    end
-    local name = string.gsub(file, "(.*" .. sep .. ")(.*)", "%2")
-    return name
 end


### PR DESCRIPTION
The linter plugin's `basename()` only treats `\` as a separator on Windows, so it never splits on `/`. If a linter normalizes the paths it prints, the name it reports can't match the buffer path and `onExit()` silently drops all its messages. For a buffer opened as `a\b\d.c`, a linter printing `a/b/d.c` gets that whole string back out of `basename()` and the compare fails. The default C linters hide this because clang and gcc echo the path back unchanged, so both sides get mangled the same way.

`filepath` is already imported here and `filepath.Base()` handles both separators on Windows and treats `\` as an ordinary filename character elsewhere, so the hand-rolled helper can go.

Fixes #3963
