### PR TITLE
chore(runtime/plugins): document all built-in plugins use `1.0.0` version 

### DIFF
--- a/runtime/plugins/autoclose/autoclose.lua
+++ b/runtime/plugins/autoclose/autoclose.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local uutil = import("micro/util")
 local utf8 = import("utf8")

--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local util = import("micro/util")
 local config = import("micro/config")

--- a/runtime/plugins/diff/diff.lua
+++ b/runtime/plugins/diff/diff.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local os = import("os")
 local filepath = import("path/filepath")

--- a/runtime/plugins/ftoptions/ftoptions.lua
+++ b/runtime/plugins/ftoptions/ftoptions.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 function onBufferOpen(b)
     local ft = b:FileType()

--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local micro = import("micro")
 local runtime = import("runtime")

--- a/runtime/plugins/literate/literate.lua
+++ b/runtime/plugins/literate/literate.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local config = import("micro/config")
 

--- a/runtime/plugins/status/status.lua
+++ b/runtime/plugins/status/status.lua
@@ -1,4 +1,4 @@
-VERSION = "1.0.0"
+VERSION = "1.0.0" -- all built-in plugins fixed to 1.0.0
 
 local micro = import("micro")
 local buffer = import("micro/buffer")


### PR DESCRIPTION
As of commit 4c47a2713aafdb105d5a45ca0f859d0e7290f617, the version of the built-in plugin is not displayed or used in any way.

Rather than removing it, keep it in the code and document that it should remain at version `1.0.0`. This way, the information remains available to contributors and users.