### PR TITLE
docs(internal/buffer): remove reference to the old `ToCharPos` function

### DIFF
--- a/internal/buffer/loc.go
+++ b/internal/buffer/loc.go
@@ -134,7 +134,7 @@ func (l Loc) Move(n int, buf *Buffer) Loc {
 	return l.MoveLA(n, buf.LineArray)
 }
 
-// ByteOffset is just like ToCharPos except it counts bytes instead of runes
+// ByteOffset converts an x, y position into a byte offset in the buffer
 func ByteOffset(pos Loc, buf *Buffer) int {
 	x, y := pos.X, pos.Y
 	loc := 0


### PR DESCRIPTION
The function was removed in commit https://github.com/micro-editor/micro/commit/dc68183fc114ab2911d6ba934cf5df019566d0cf.