### PR TITLE
fix(runtime): TrimLeft() -> TrimPrefix() in `fixPath()`

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,7 +12,7 @@ import (
 var runtime embed.FS
 
 func fixPath(name string) string {
-	return strings.TrimLeft(filepath.ToSlash(name), "runtime/")
+	return strings.TrimPrefix(filepath.ToSlash(name), "runtime/")
 }
 
 // AssetDir lists file names in folder


### PR DESCRIPTION
Closes #2802