### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To see more screenshots of micro, showcasing some of the default color schemes, 
 
 You can also check out the website for Micro at https://micro-editor.github.io.
 
+[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Amicro)
+
 - - -
 
 ## Features


### PR DESCRIPTION
Adds a "Online demo" link to the README pointing to micro running in the browser: https://gallery.demoshell.com/app/micro/

It's the actual micro binary inside an emulated Linux VM (WebAssembly). The VM is seeded with a few source files to edit, and the familiar keybindings work in the embedded terminal. The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution).

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it.