### PR TITLE
Add `ambiguouswidth` option

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -601,6 +601,8 @@ func doSetGlobalOptionNative(option string, nativeValue any) error {
 		} else {
 			config.SetAutoTime(0)
 		}
+	} else if option == "ambiguouswidth" {
+		util.SetAmbiguousWidth(nativeValue.(string))
 	} else if option == "paste" {
 		screen.Screen.SetPaste(nativeValue.(bool))
 	} else if option == "clipboard" {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -21,6 +21,7 @@ type optionValidator func(string, any) error
 
 // a list of settings that need option validators
 var optionValidators = map[string]optionValidator{
+	"ambiguouswidth":  validateChoice,
 	"autosave":        validateNonNegativeValue,
 	"clipboard":       validateChoice,
 	"colorcolumn":     validateNonNegativeValue,
@@ -41,6 +42,7 @@ var optionValidators = map[string]optionValidator{
 
 // a list of settings with pre-defined choices
 var OptionChoices = map[string][]string{
+	"ambiguouswidth":  {"auto", "single", "double"},
 	"clipboard":       {"internal", "external", "terminal"},
 	"fileformat":      {"unix", "dos"},
 	"helpsplit":       {"hsplit", "vsplit"},
@@ -110,6 +112,7 @@ var defaultCommonSettings = map[string]any{
 // a list of settings that should only be globally modified and their
 // default values
 var DefaultGlobalOnlySettings = map[string]any{
+	"ambiguouswidth": "auto",
 	"autosave":       float64(0),
 	"clipboard":      "external",
 	"colorscheme":    "default",

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/micro-editor/micro/v2/internal/config"
+	"github.com/micro-editor/micro/v2/internal/util"
 	"github.com/micro-editor/tcell/v2"
 )
 
@@ -181,6 +182,8 @@ func TempStart(screenWasNil bool) {
 // Init creates and initializes the tcell screen
 func Init() error {
 	drawChan = make(chan bool, 8)
+
+	util.SetAmbiguousWidth(config.GetGlobalOption("ambiguouswidth").(string))
 
 	// Should we enable true color?
 	truecolor := config.GetGlobalOption("truecolor").(string)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -104,15 +104,18 @@ var envAmbiguousWide bool
 // to be: one column ("single"), two columns ("double") or as many columns
 // as the environment implies ("auto")
 func SetAmbiguousWidth(mode string) {
+	var wide bool
 	switch mode {
 	case "single":
-		runewidth.EastAsianWidth = false
+		wide = false
 	case "double":
-		runewidth.EastAsianWidth = true
+		wide = true
 	default:
-		runewidth.EastAsianWidth = envAmbiguousWide
+		wide = envAmbiguousWide
 	}
-	runewidth.DefaultCondition.EastAsianWidth = runewidth.EastAsianWidth
+	// go-runewidth syncs DefaultCondition with runewidth.EastAsianWidth only
+	// once, in its init(), so overriding it later has to be done here
+	runewidth.DefaultCondition.EastAsianWidth = wide
 }
 
 // SliceEnd returns a byte slice where the index is a rune index

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -91,6 +91,28 @@ func init() {
 	}
 
 	Stdout = new(bytes.Buffer)
+
+	envAmbiguousWide = runewidth.EastAsianWidth
+}
+
+// envAmbiguousWide is the ambiguous width detected from the environment
+// (the locale environment variables and RUNEWIDTH_EASTASIAN) at startup
+var envAmbiguousWide bool
+
+// SetAmbiguousWidth sets how wide the characters with the East Asian
+// Ambiguous width property (see Unicode Standard Annex #11) are considered
+// to be: one column ("single"), two columns ("double") or as many columns
+// as the environment implies ("auto")
+func SetAmbiguousWidth(mode string) {
+	switch mode {
+	case "single":
+		runewidth.EastAsianWidth = false
+	case "double":
+		runewidth.EastAsianWidth = true
+	default:
+		runewidth.EastAsianWidth = envAmbiguousWide
+	}
+	runewidth.DefaultCondition.EastAsianWidth = runewidth.EastAsianWidth
 }
 
 // SliceEnd returns a byte slice where the index is a rune index

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -13,6 +13,31 @@ func TestStringWidth(t *testing.T) {
 	assert.Equal(t, 26, n)
 }
 
+func TestSetAmbiguousWidth(t *testing.T) {
+	defer SetAmbiguousWidth("auto")
+
+	// U+03B1 is ambiguous width, U+3042 is wide, U+0061 is narrow
+	bytes := []byte("\u03b1\u3042a")
+
+	SetAmbiguousWidth("single")
+	assert.Equal(t, 1, StringWidth(bytes, 1, 4))
+	assert.Equal(t, 3, StringWidth(bytes, 2, 4))
+	assert.Equal(t, 4, StringWidth(bytes, 3, 4))
+
+	SetAmbiguousWidth("double")
+	assert.Equal(t, 2, StringWidth(bytes, 1, 4))
+	assert.Equal(t, 4, StringWidth(bytes, 2, 4))
+	assert.Equal(t, 5, StringWidth(bytes, 3, 4))
+
+	// "auto" restores the width implied by the environment
+	SetAmbiguousWidth("auto")
+	expected := 1
+	if envAmbiguousWide {
+		expected = 2
+	}
+	assert.Equal(t, expected, StringWidth(bytes, 1, 4))
+}
+
 func TestSliceVisualEnd(t *testing.T) {
 	s := []byte("\thello")
 	slc, n, _ := SliceVisualEnd(s, 2, 4)

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -11,6 +11,23 @@ if you have set either of the above environment variables).
 
 Here are the available options:
 
+* `ambiguouswidth`: how wide the characters with the East Asian Ambiguous
+   width property (as defined by [Unicode Standard Annex
+   #11](https://www.unicode.org/reports/tr11)) are considered to be. These
+   characters, e.g. Greek and Cyrillic letters, accented Latin letters and box
+   drawing characters, are drawn one column wide by most terminals but two
+   columns wide by some terminals in an East Asian environment. If micro's
+   choice does not match your terminal, text is misaligned and the cursor is
+   drawn in the wrong column. This setting is `global only`.
+   * `auto`: use two columns if the locale environment variables (`LC_ALL`,
+      `LC_CTYPE`, `LANG`) indicate a Chinese, Japanese or Korean locale,
+      otherwise one column. Can be overridden with the `RUNEWIDTH_EASTASIAN`
+      environment variable.
+   * `single`: always use one column, like `wcwidth(3)` and most terminals do.
+   * `double`: always use two columns.
+
+    default value: `auto`
+
 * `autoindent`: when creating a new line, use the same indentation as the
    previous line.
 


### PR DESCRIPTION
### Description

Characters with the East Asian Ambiguous width property (Greek, Cyrillic, accented Latin) are measured as two columns whenever `LANG`/`LC_*` names a CJK locale, as go-runewidth autodetects. Most terminals draw them one column wide, so text is misaligned and the cursor sits in the wrong column (#1124). This adds an `ambiguouswidth` option, shaped after `truecolor`.

Measured in a pty, `LANG=ja_JP.UTF-8`, buffer `let αβγ = 0`: with `auto` tcell moves two columns per rune (`α ESC[1;9H β ESC[1;11H γ ESC[1;13H`, cursor ends at column 17); with `single` the runes are contiguous and the cursor ends at column 14. glibc 2.39 and musl 1.2.5 `wcwidth()` both return 1 for these code points under `ja_JP.UTF-8`, so the doubling is micro's choice, not libc's.

Open question: the default. I kept `auto`, so nothing changes; `single` would match wcwidth and the editors mentioned in the issue.

### User-Facing Changes

New global-only option `ambiguouswidth` (`auto`/`single`/`double`), applied on `set` and documented in `options.md`. Nothing changes at the default.

### Tests

`TestSetAmbiguousWidth` in `internal/util`; `go test ./...` passes. Mutation-checked: making `single` set wide, or dropping the `DefaultCondition` sync, each turns it red. Also reconciled against the UAX #11 15.1.0 file (what go-runewidth v0.0.16 is generated from): of its 138,739 Ambiguous code points, 138,626 flip 1->2 and 113 are zero-width combining marks; 0 of 209,089 non-Ambiguous ones change.
