### PR TITLE
Fix reload diffs for CRLF and combining characters

### DIFF
--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -2,7 +2,9 @@ package buffer
 
 import (
 	"bytes"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/micro-editor/micro/v2/internal/config"
 	ulua "github.com/micro-editor/micro/v2/internal/lua"
@@ -161,23 +163,94 @@ func NewEventHandler(buf *SharedBuffer, cursors []*Cursor) *EventHandler {
 }
 
 // ApplyDiff takes a string and runs the necessary insertion and deletion events to make
-// the buffer equal to that string
+// the buffer equal to that string, using the buffer's line ending format.
 // This means that we can transform the buffer into any string and still preserve undo/redo
 // through insert and delete events
 func (eh *EventHandler) ApplyDiff(new string) {
-	differ := dmp.New()
-	diff := differ.DiffMain(string(eh.buf.Bytes()), new, false)
+	// Read raw lines so the snapshot does not depend on character coordinates.
+	// Line separators are LF regardless of the file's on-disk format.
+	var old strings.Builder
+	for i := 0; i < eh.buf.LinesNum(); i++ {
+		if i > 0 {
+			old.WriteByte('\n')
+		}
+		old.Write(eh.buf.LineBytes(i))
+	}
+	new = strings.ReplaceAll(new, "\r\n", "\n")
+	if old.String() == new {
+		return
+	}
+	diff := diffCharacters(old.String(), new)
 	loc := eh.buf.Start()
 	for _, d := range diff {
+		// Advance in buffer coordinates, without walking the changing line array.
+		end := loc
+		if lastnl := strings.LastIndexByte(d.Text, '\n'); lastnl >= 0 {
+			end.Y += strings.Count(d.Text, "\n")
+			end.X = util.CharacterCountInString(d.Text[lastnl+1:])
+		} else {
+			end.X += util.CharacterCountInString(d.Text)
+		}
 		if d.Type == dmp.DiffDelete {
-			eh.Remove(loc, loc.MoveLA(util.CharacterCountInString(d.Text), eh.buf.LineArray))
+			eh.Remove(loc, end)
 		} else {
 			if d.Type == dmp.DiffInsert {
 				eh.Insert(loc, d.Text)
 			}
-			loc = loc.MoveLA(util.CharacterCountInString(d.Text), eh.buf.LineArray)
+			loc = end
 		}
 	}
+}
+
+// diffCharacters diffs whole buffer characters: a rune and its combining marks.
+// The diff library operates on runes, so give each distinct character a rune ID
+// shared by both inputs. This keeps edit boundaries out of combining sequences.
+func diffCharacters(old, new string) []dmp.Diff {
+	characters := []string{""}
+	ids := make(map[string]rune)
+	encode := func(text string) ([]rune, bool) {
+		var encoded []rune
+		for len(text) > 0 {
+			size := 1
+			if text[0] != '\n' {
+				_, _, size = util.DecodeCharacterInString(text)
+			}
+			character := text[:size]
+			text = text[size:]
+			id, ok := ids[character]
+			if !ok {
+				// IDs must survive the library's conversion from runes to strings.
+				if len(characters) == 0xd800 {
+					characters = append(characters, make([]string, 0x800)...)
+				}
+				if len(characters) > utf8.MaxRune {
+					return nil, false
+				}
+				id = rune(len(characters))
+				ids[character] = id
+				characters = append(characters, character)
+			}
+			encoded = append(encoded, id)
+		}
+		return encoded, true
+	}
+	oldRunes, oldOK := encode(old)
+	newRunes, newOK := encode(new)
+	if !oldOK || !newOK {
+		// A whole-text edit is still reversible if there are too many distinct
+		// characters to represent with Unicode scalar values.
+		return []dmp.Diff{{Type: dmp.DiffDelete, Text: old}, {Type: dmp.DiffInsert, Text: new}}
+	}
+	differ := dmp.New()
+	diffs := differ.DiffMainRunes(oldRunes, newRunes, false)
+	for i := range diffs {
+		var text strings.Builder
+		for _, id := range diffs[i].Text {
+			text.WriteString(characters[id])
+		}
+		diffs[i].Text = text.String()
+	}
+	return diffs
 }
 
 // Insert creates an insert text event and executes it

--- a/internal/buffer/eventhandler_diff_test.go
+++ b/internal/buffer/eventhandler_diff_test.go
@@ -1,0 +1,85 @@
+package buffer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestApplyDiffUnchangedLeadingMarks(t *testing.T) {
+	for _, text := range []string{"\u0301a", "\u0301", "first\n\u0301ab", "first\r\n\u0301ab"} {
+		b := NewBufferFromString(text, "", BTDefault)
+		b.GetActiveCursor().GotoLoc(Loc{1, 0})
+		cursor := b.GetActiveCursor().Loc
+		b.ApplyDiff(text)
+		if got := string(b.Bytes()); got != text {
+			t.Errorf("unchanged reload: got %q, want %q", got, text)
+		}
+		if b.UndoStack.Len() != 0 || b.GetActiveCursor().Loc != cursor {
+			t.Error("unchanged reload altered undo history or cursor")
+		}
+		b.Close()
+	}
+}
+
+func TestApplyDiffManyDistinctCharacters(t *testing.T) {
+	// More than 0xd800 distinct characters exercises rune IDs across the
+	// surrogate range, which cannot be represented in UTF-8 strings.
+	var text strings.Builder
+	for r := rune(0x20000); r < 0x20000+56000; r++ {
+		text.WriteRune(r)
+		text.WriteString("\u0301")
+	}
+	before := text.String()
+	after := before + "!"
+	b := NewBufferFromString(before, "", BTDefault)
+	defer b.Close()
+	b.ApplyDiff(after)
+	if got := string(b.Bytes()); got != after {
+		t.Fatal("reload corrupted a buffer with many distinct characters")
+	}
+	b.UndoOneEvent()
+	if got := string(b.Bytes()); got != before {
+		t.Fatal("undo corrupted a buffer with many distinct characters")
+	}
+}
+
+func TestApplyDiffRandomEdits(t *testing.T) {
+	random := rand.New(rand.NewSource(3303))
+	characters := []string{"a", "b", " ", "e\u0301", "a\u0302\u0327", "\u4e16", "\U0001f4da", "\n"}
+	randomText := func() string {
+		var text strings.Builder
+		for n := random.Intn(60); n > 0; n-- {
+			text.WriteString(characters[random.Intn(len(characters))])
+		}
+		return text.String()
+	}
+	for i := 0; i < 200; i++ {
+		before, after := randomText(), randomText()
+		endings := FFUnix
+		if i%2 == 0 {
+			before = strings.ReplaceAll(before, "\n", "\r\n")
+			after = strings.ReplaceAll(after, "\n", "\r\n")
+			endings = FFDos
+		}
+		b := NewBufferFromString(before, "", BTDefault)
+		b.Endings = FileFormat(endings)
+		b.ApplyDiff(after)
+		if got := string(b.Bytes()); got != after {
+			t.Fatalf("case %d: %q -> %q produced %q", i, before, after, got)
+		}
+		for b.UndoStack.Len() > 0 {
+			b.UndoOneEvent()
+		}
+		if got := string(b.Bytes()); got != before {
+			t.Fatalf("case %d: undo got %q, want %q", i, got, before)
+		}
+		for b.RedoStack.Len() > 0 {
+			b.RedoOneEvent()
+		}
+		if got := string(b.Bytes()); got != after {
+			t.Fatalf("case %d: redo got %q, want %q", i, got, after)
+		}
+		b.Close()
+	}
+}

--- a/internal/buffer/eventhandler_test.go
+++ b/internal/buffer/eventhandler_test.go
@@ -1,0 +1,198 @@
+package buffer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyDiff(t *testing.T) {
+	tests := []struct {
+		name   string
+		before string
+		after  string
+	}{
+		{"unchanged", "one\ntwo\n", "one\ntwo\n"},
+		{"insert", "one\ntwo\n", "one\nnew two\n"},
+		{"delete", "one\nold two\n", "one\ntwo\n"},
+		{"replace", "569\n489\n45\n", "569\n123\n456\n"},
+		{"empty", "", ""},
+		{"insert into empty", "", "one\ntwo\n"},
+		{"delete all", "one\ntwo\n", ""},
+		{"add final newline", "one\ntwo", "one\ntwo\n"},
+		{"remove final newline", "one\ntwo\n", "one\ntwo"},
+		{"blank lines", "one\n\n\ntwo\n", "\none\n\ntwo\n\n"},
+		{"remove mark", "Te\u0302st\n", "Test\n"},
+		{"add mark", "Test\n", "Te\u0302st\n"},
+		{"replace mark", "Te\u0302st\n", "Te\u0301st\n"},
+		{"replace base", "Te\u0302st\n", "Ta\u0302st\n"},
+		{"multiple marks", "a\u0301\u0327bc\nkeep\n", "a\u0327b\u0302c!\nkeep\n"},
+		{"marks around newline", "a\u0301\nb\u0302\n", "a\u0301b\u0302\n"},
+		{"split marked line", "a\u0301b\u0302\n", "a\u0301\nb\u0302\n"},
+		{"utf8", "\u4e16\u754c \U0001f4da caf\u00e9\n\u0645\n", "\u4e16\u754c! \U0001f4d6 cafe\u0301\n\u0645\u0646\n"},
+		{"literal carriage return", "one\rtwo\nend\r", "one\rnew two\nend\r!"},
+	}
+	for _, endings := range []string{"\n", "\r\n"} {
+		format := FFUnix
+		name := "LF"
+		if endings == "\r\n" {
+			format = FFDos
+			name = "CRLF"
+		}
+		for _, tt := range tests {
+			t.Run(name+"/"+tt.name, func(t *testing.T) {
+				before := strings.ReplaceAll(tt.before, "\n", endings)
+				after := strings.ReplaceAll(tt.after, "\n", endings)
+				b := NewBufferFromString(before, "", BTDefault)
+				defer b.Close()
+				b.Endings = FileFormat(format)
+				b.ApplyDiff(after)
+				if got := string(b.Bytes()); got != after {
+					t.Fatalf("ApplyDiff: got %q, want %q", got, after)
+				}
+				events := b.UndoStack.Len()
+				if (events == 0) != (before == after) {
+					t.Fatalf("got %d undo events for %q -> %q", events, before, after)
+				}
+				for i := 0; i < events; i++ {
+					b.UndoOneEvent()
+				}
+				if got := string(b.Bytes()); got != before {
+					t.Fatalf("undo: got %q, want %q", got, before)
+				}
+				for i := 0; i < events; i++ {
+					b.RedoOneEvent()
+				}
+				if got := string(b.Bytes()); got != after {
+					t.Fatalf("redo: got %q, want %q", got, after)
+				}
+			})
+		}
+	}
+}
+
+func TestApplyDiffNormalizesLineEndings(t *testing.T) {
+	for _, before := range []string{"one\ntwo\n", "one\r\ntwo\r\n"} {
+		for _, after := range []string{"one\ntwo\n", "one\r\ntwo\r\n", "one\r\ntwo\n"} {
+			b := NewBufferFromString(before, "", BTDefault)
+			b.ApplyDiff(after)
+			if got := string(b.Bytes()); got != before {
+				t.Errorf("line ending change: got %q, want %q", got, before)
+			}
+			if b.UndoStack.Len() != 0 {
+				t.Error("line ending normalization created text events")
+			}
+			b.Close()
+		}
+	}
+}
+
+func TestApplyDiffPreservesCursors(t *testing.T) {
+	for _, endings := range []string{"\n", "\r\n"} {
+		before := "The bottle says DRINK ME" + endings + "Te\u0302st" + endings + "keep"
+		after := "The cake says EAT ME" + endings + "Test!" + endings + "keep"
+		b := NewBufferFromString(before, "", BTDefault)
+		b.GetActiveCursor().GotoLoc(Loc{22, 0})
+		b.AddCursor(NewCursor(b, Loc{4, 1}))
+		b.AddCursor(NewCursor(b, Loc{2, 2}))
+		b.ApplyDiff(after)
+		for i, want := range []Loc{{18, 0}, {5, 1}, {2, 2}} {
+			if got := b.GetCursor(i).Loc; got != want {
+				t.Errorf("cursor %d with %q endings: got %v, want %v", i, endings, got, want)
+			}
+		}
+		for b.UndoStack.Len() > 0 {
+			b.UndoOneEvent()
+		}
+		if got := b.GetActiveCursor().Loc; got != (Loc{22, 0}) {
+			t.Errorf("undo cursor: got %v, want {22 0}", got)
+		}
+		b.Close()
+	}
+}
+
+func TestApplyDiffPreservesUndoHistory(t *testing.T) {
+	b := NewBufferFromString("one\nkeep\n", "", BTDefault)
+	defer b.Close()
+	b.Insert(Loc{3, 0}, "!")
+	prior := b.UndoStack.Peek()
+	b.ApplyDiff("two\nkeep\n")
+	for b.UndoStack.Len() > 1 {
+		b.UndoOneEvent()
+	}
+	if b.UndoStack.Peek() != prior || string(b.Bytes()) != "one!\nkeep\n" {
+		t.Fatalf("reload did not preserve the prior edit: %q", b.Bytes())
+	}
+	b.UndoOneEvent()
+	if got := string(b.Bytes()); got != "one\nkeep\n" {
+		t.Fatalf("undo prior edit: got %q", got)
+	}
+	for b.RedoStack.Len() > 0 {
+		b.RedoOneEvent()
+	}
+	if got := string(b.Bytes()); got != "two\nkeep\n" {
+		t.Fatalf("redo history: got %q", got)
+	}
+}
+
+func TestReOpenDiff(t *testing.T) {
+	for _, endings := range []string{"\n", "\r\n"} {
+		t.Run(strings.ReplaceAll(endings, "\n", "LF"), func(t *testing.T) {
+			before := strings.ReplaceAll("head\nTe\u0302st\nkeep\nremove\ntail\n", "\n", endings)
+			after := strings.ReplaceAll("head\nTest\nkeep\ntail\nadded\n", "\n", endings)
+			path := filepath.Join(t.TempDir(), "reload.txt")
+			if err := os.WriteFile(path, []byte(before), 0600); err != nil {
+				t.Fatal(err)
+			}
+			b, err := NewBufferFromFile(path, BTDefault)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Close()
+			b.Settings["savecursor"] = false
+			b.Settings["saveundo"] = false
+			b.Settings["diffgutter"] = true
+			b.SetDiffBase([]byte(before))
+			b.GetActiveCursor().GotoLoc(Loc{2, 4})
+			if err := os.WriteFile(path, []byte(after), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.ReOpen(); err != nil {
+				t.Fatal(err)
+			}
+			if got := string(b.Bytes()); got != after {
+				t.Fatalf("ReOpen: got %q, want %q", got, after)
+			}
+			if b.Modified() {
+				t.Error("reopened buffer is marked modified")
+			}
+			if got := b.GetActiveCursor().Loc; got != (Loc{2, 3}) {
+				t.Errorf("reopened cursor: got %v, want {2 3}", got)
+			}
+			checkDiff := func(want []DiffStatus) {
+				t.Helper()
+				b.UpdateDiff()
+				for i, status := range want {
+					if got := b.DiffStatus(i); got != status {
+						t.Errorf("diffgutter line %d: got %d, want %d", i, got, status)
+					}
+				}
+			}
+			statuses := []DiffStatus{DSUnchanged, DSModified, DSUnchanged, DSDeletedAbove, DSAdded, DSUnchanged}
+			checkDiff(statuses)
+			for b.Undo() {
+			}
+			if got := string(b.Bytes()); got != before {
+				t.Fatalf("undo reopen: got %q, want %q", got, before)
+			}
+			checkDiff(make([]DiffStatus, 6))
+			for b.Redo() {
+			}
+			if got := string(b.Bytes()); got != after {
+				t.Fatalf("redo reopen: got %q, want %q", got, after)
+			}
+			checkDiff(statuses)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3303.

Reloading an externally changed CRLF file can apply edits at the wrong buffer positions. The diff counts CR and LF separately, while buffer coordinates use one line break. Rune-level diffs can also split a base character from its combining marks, making some changes impossible to apply or undo correctly.

Diff complete buffer characters, using micro's existing base-rune-plus-marks model. Read the old text directly from the buffer's lines, normalize incoming CRLF separators, and advance locations by line and character column. Edits still go through the existing insert/delete events, preserving cursor movement, undo history, and diffgutter updates. Line-ending-only changes retain the current file format and create no text events.

Regression coverage includes LF and CRLF edits, empty buffers, final newlines, literal carriage returns, UTF-8, adding/removing/replacing combining marks, multiple cursors, undo/redo history, and file-backed ReOpen with diffgutter assertions. Additional cases cover unchanged text beginning with a combining mark, 56,000 distinct characters, and 200 deterministic randomized edits.

Validation on Windows:
- Confirmed the reported CRLF and combining-mark regressions fail before the fix.
- `go test ./... -count=1` passes.
- `go build ./cmd/micro` passes.
- Formatting and `git diff --check` pass.