### PR TITLE
Enforce readonly in the buffer mutation layer

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -123,7 +123,14 @@ type SharedBuffer struct {
 	origHash [md5.Size]byte
 }
 
-func (b *SharedBuffer) insert(pos Loc, value []byte) {
+func (b *SharedBuffer) canEdit(permission textEventPermission) bool {
+	return !b.Type.Readonly || permission == internalEdit
+}
+
+func (b *SharedBuffer) insert(pos Loc, value []byte, permission textEventPermission) {
+	if !b.canEdit(permission) {
+		return
+	}
 	b.HasSuggestions = false
 	b.LineArray.insert(pos, value)
 	b.setModified()
@@ -132,7 +139,10 @@ func (b *SharedBuffer) insert(pos Loc, value []byte) {
 	b.MarkModified(pos.Y, pos.Y+inslines)
 }
 
-func (b *SharedBuffer) remove(start, end Loc) []byte {
+func (b *SharedBuffer) remove(start, end Loc, permission textEventPermission) []byte {
+	if !b.canEdit(permission) {
+		return nil
+	}
 	b.HasSuggestions = false
 	defer b.setModified()
 	defer b.MarkModified(start.Y, end.Y)
@@ -563,20 +573,16 @@ func (b *Buffer) SetName(s string) {
 
 // Insert inserts the given string of text at the start location
 func (b *Buffer) Insert(start Loc, text string) {
-	if !b.Type.Readonly {
-		b.EventHandler.cursors = b.cursors
-		b.EventHandler.active = b.curCursor
-		b.EventHandler.Insert(start, text)
-	}
+	b.EventHandler.cursors = b.cursors
+	b.EventHandler.active = b.curCursor
+	b.EventHandler.Insert(start, text)
 }
 
 // Remove removes the characters between the start and end locations
 func (b *Buffer) Remove(start, end Loc) {
-	if !b.Type.Readonly {
-		b.EventHandler.cursors = b.cursors
-		b.EventHandler.active = b.curCursor
-		b.EventHandler.Remove(start, end)
-	}
+	b.EventHandler.cursors = b.cursors
+	b.EventHandler.active = b.curCursor
+	b.EventHandler.Remove(start, end)
 }
 
 // FileType returns the buffer's filetype
@@ -620,7 +626,8 @@ func (b *Buffer) ReOpen() error {
 	if err != nil {
 		return err
 	}
-	b.EventHandler.ApplyDiff(txt)
+	// Reload reflects the file on disk even when user edits are disabled.
+	b.EventHandler.applyDiff(txt, internalEdit)
 
 	err = b.UpdateModTime()
 	if !b.Settings["fastdirty"].(bool) {
@@ -1143,7 +1150,7 @@ func (b *Buffer) MoveLinesUp(start int, end int) {
 				util.CharacterCount(b.lines[end-1].data),
 				end - 1,
 			},
-			[]byte{'\n'},
+			[]byte{'\n'}, userEdit,
 		)
 	}
 	b.Insert(
@@ -1271,11 +1278,13 @@ func (b *Buffer) FindMatchingBrace(start Loc) (Loc, bool, bool) {
 func (b *Buffer) Retab() {
 	toSpaces := b.Settings["tabstospaces"].(bool)
 	tabsize := util.IntOpt(b.Settings["tabsize"])
+	var deltas []Delta
 
 	for i := 0; i < b.LinesNum(); i++ {
 		l := b.LineBytes(i)
 
 		ws := util.GetLeadingWhitespace(l)
+		oldws := ws
 		if len(ws) != 0 {
 			if toSpaces {
 				ws = bytes.ReplaceAll(ws, []byte{'\t'}, bytes.Repeat([]byte{' '}, tabsize))
@@ -1284,16 +1293,14 @@ func (b *Buffer) Retab() {
 			}
 		}
 
-		l = bytes.TrimLeft(l, " \t")
-
-		b.Lock()
-		b.lines[i].data = append(ws, l...)
-		b.Unlock()
-
-		b.MarkModified(i, i)
+		if !bytes.Equal(oldws, ws) {
+			deltas = append(deltas, Delta{ws, Loc{0, i}, Loc{util.CharacterCount(oldws), i}})
+		}
 	}
 
-	b.setModified()
+	if len(deltas) > 0 {
+		b.MultipleReplace(deltas)
+	}
 }
 
 // ParseCursorLocation turns a cursor location like 10:5 (LINE:COL)
@@ -1326,8 +1333,15 @@ func (b *Buffer) Line(i int) string {
 	return string(b.LineBytes(i))
 }
 
+// Write appends output. Only log buffers accept output while read-only.
 func (b *Buffer) Write(bytes []byte) (n int, err error) {
-	b.EventHandler.InsertBytes(b.End(), bytes)
+	permission := userEdit
+	if b.Type.Kind == BTLog.Kind {
+		permission = internalEdit
+	} else if b.Type.Readonly {
+		return 0, errors.New("cannot write to read-only buffer")
+	}
+	b.EventHandler.insertBytes(b.End(), bytes, permission)
 	return len(bytes), nil
 }
 
@@ -1470,7 +1484,7 @@ func (b *Buffer) SearchMatch(pos Loc) bool {
 
 // WriteLog writes a string to the log buffer
 func WriteLog(s string) {
-	LogBuf.EventHandler.Insert(LogBuf.End(), s)
+	LogBuf.Write([]byte(s))
 }
 
 // GetLogBuf returns the log buffer

--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -41,14 +41,32 @@ type Delta struct {
 	End   Loc
 }
 
+// Internal updates carry permission on the call, never on the shared buffer.
+// A plugin called during an internal update still uses the guarded public API.
+type textEventPermission bool
+
+const (
+	userEdit     textEventPermission = false
+	internalEdit textEventPermission = true
+)
+
 // DoTextEvent runs a text event
 func (eh *EventHandler) DoTextEvent(t *TextEvent, useUndo bool) {
+	eh.doTextEvent(t, useUndo, userEdit)
+}
+
+func (eh *EventHandler) doTextEvent(t *TextEvent, useUndo bool, permission textEventPermission) {
+	if !eh.buf.canEdit(permission) {
+		return
+	}
 	oldl := eh.buf.LinesNum()
 
 	if useUndo {
-		eh.Execute(t)
+		if !eh.execute(t, permission) {
+			return
+		}
 	} else {
-		ExecuteTextEvent(t, eh.buf)
+		executeTextEvent(t, eh.buf, permission)
 	}
 
 	if len(t.Deltas) != 1 {
@@ -114,18 +132,26 @@ func (eh *EventHandler) DoTextEvent(t *TextEvent, useUndo bool) {
 
 // ExecuteTextEvent runs a text event
 func ExecuteTextEvent(t *TextEvent, buf *SharedBuffer) {
+	if !buf.canEdit(userEdit) {
+		return
+	}
+	executeTextEvent(t, buf, userEdit)
+}
+
+// executeTextEvent applies an event whose permission has already been checked.
+func executeTextEvent(t *TextEvent, buf *SharedBuffer, permission textEventPermission) {
 	if t.EventType == TextEventInsert {
 		for _, d := range t.Deltas {
-			buf.insert(d.Start, d.Text)
+			buf.insert(d.Start, d.Text, permission)
 		}
 	} else if t.EventType == TextEventRemove {
 		for i, d := range t.Deltas {
-			t.Deltas[i].Text = buf.remove(d.Start, d.End)
+			t.Deltas[i].Text = buf.remove(d.Start, d.End, permission)
 		}
 	} else if t.EventType == TextEventReplace {
 		for i, d := range t.Deltas {
-			t.Deltas[i].Text = buf.remove(d.Start, d.End)
-			buf.insert(d.Start, d.Text)
+			t.Deltas[i].Text = buf.remove(d.Start, d.End, permission)
+			buf.insert(d.Start, d.Text, permission)
 			t.Deltas[i].Start = d.Start
 			t.Deltas[i].End = Loc{d.Start.X + util.CharacterCount(d.Text), d.Start.Y}
 		}
@@ -137,6 +163,9 @@ func ExecuteTextEvent(t *TextEvent, buf *SharedBuffer) {
 
 // UndoTextEvent undoes a text event
 func (eh *EventHandler) UndoTextEvent(t *TextEvent) {
+	if !eh.buf.canEdit(userEdit) {
+		return
+	}
 	t.EventType = -t.EventType
 	eh.DoTextEvent(t, false)
 }
@@ -165,15 +194,22 @@ func NewEventHandler(buf *SharedBuffer, cursors []*Cursor) *EventHandler {
 // This means that we can transform the buffer into any string and still preserve undo/redo
 // through insert and delete events
 func (eh *EventHandler) ApplyDiff(new string) {
+	eh.applyDiff(new, userEdit)
+}
+
+func (eh *EventHandler) applyDiff(new string, permission textEventPermission) {
+	if !eh.buf.canEdit(permission) {
+		return
+	}
 	differ := dmp.New()
 	diff := differ.DiffMain(string(eh.buf.Bytes()), new, false)
 	loc := eh.buf.Start()
 	for _, d := range diff {
 		if d.Type == dmp.DiffDelete {
-			eh.Remove(loc, loc.MoveLA(util.CharacterCountInString(d.Text), eh.buf.LineArray))
+			eh.remove(loc, loc.MoveLA(util.CharacterCountInString(d.Text), eh.buf.LineArray), permission)
 		} else {
 			if d.Type == dmp.DiffInsert {
-				eh.Insert(loc, d.Text)
+				eh.insertBytes(loc, []byte(d.Text), permission)
 			}
 			loc = loc.MoveLA(util.CharacterCountInString(d.Text), eh.buf.LineArray)
 		}
@@ -188,6 +224,10 @@ func (eh *EventHandler) Insert(start Loc, textStr string) {
 
 // InsertBytes creates an insert text event and executes it
 func (eh *EventHandler) InsertBytes(start Loc, text []byte) {
+	eh.insertBytes(start, text, userEdit)
+}
+
+func (eh *EventHandler) insertBytes(start Loc, text []byte, permission textEventPermission) {
 	if len(text) == 0 {
 		return
 	}
@@ -198,11 +238,15 @@ func (eh *EventHandler) InsertBytes(start Loc, text []byte) {
 		Deltas:    []Delta{{text, start, Loc{0, 0}}},
 		Time:      time.Now(),
 	}
-	eh.DoTextEvent(e, true)
+	eh.doTextEvent(e, true, permission)
 }
 
 // Remove creates a remove text event and executes it
 func (eh *EventHandler) Remove(start, end Loc) {
+	eh.remove(start, end, userEdit)
+}
+
+func (eh *EventHandler) remove(start, end Loc, permission textEventPermission) {
 	if start == end {
 		return
 	}
@@ -214,7 +258,7 @@ func (eh *EventHandler) Remove(start, end Loc) {
 		Deltas:    []Delta{{[]byte{}, start, end}},
 		Time:      time.Now(),
 	}
-	eh.DoTextEvent(e, true)
+	eh.doTextEvent(e, true, permission)
 }
 
 // MultipleReplace creates a replace text event with multiple deltas and executes it
@@ -236,25 +280,37 @@ func (eh *EventHandler) Replace(start, end Loc, replace string) {
 
 // Execute a textevent and add it to the undo stack
 func (eh *EventHandler) Execute(t *TextEvent) {
-	if eh.RedoStack.Len() > 0 {
-		eh.RedoStack = new(TEStack)
+	eh.execute(t, userEdit)
+}
+
+func (eh *EventHandler) execute(t *TextEvent, permission textEventPermission) bool {
+	if !eh.buf.canEdit(permission) {
+		return false
 	}
-	eh.UndoStack.Push(t)
 
 	b, err := config.RunPluginFnBool(nil, "onBeforeTextEvent", luar.New(ulua.L, eh.buf), luar.New(ulua.L, t))
 	if err != nil {
 		screen.TermMessage(err)
 	}
 
-	if !b {
-		return
+	// A plugin may have made the buffer read-only while handling the event.
+	if !b || !eh.buf.canEdit(permission) {
+		return false
 	}
 
-	ExecuteTextEvent(t, eh.buf)
+	if eh.RedoStack.Len() > 0 {
+		eh.RedoStack = new(TEStack)
+	}
+	eh.UndoStack.Push(t)
+	executeTextEvent(t, eh.buf, permission)
+	return true
 }
 
-// Undo the first event in the undo stack. Returns false if the stack is empty.
+// Undo the first event in the undo stack. Returns false if read-only or empty.
 func (eh *EventHandler) Undo() bool {
+	if !eh.buf.canEdit(userEdit) {
+		return false
+	}
 	t := eh.UndoStack.Peek()
 	if t == nil {
 		return false
@@ -280,6 +336,9 @@ func (eh *EventHandler) Undo() bool {
 
 // UndoOneEvent undoes one event
 func (eh *EventHandler) UndoOneEvent() {
+	if !eh.buf.canEdit(userEdit) {
+		return
+	}
 	// This event should be undone
 	// Pop it off the stack
 	t := eh.UndoStack.Pop()
@@ -300,8 +359,11 @@ func (eh *EventHandler) UndoOneEvent() {
 	eh.RedoStack.Push(t)
 }
 
-// Redo the first event in the redo stack. Returns false if the stack is empty.
+// Redo the first event in the redo stack. Returns false if read-only or empty.
 func (eh *EventHandler) Redo() bool {
+	if !eh.buf.canEdit(userEdit) {
+		return false
+	}
 	t := eh.RedoStack.Peek()
 	if t == nil {
 		return false
@@ -327,6 +389,9 @@ func (eh *EventHandler) Redo() bool {
 
 // RedoOneEvent redoes one event
 func (eh *EventHandler) RedoOneEvent() {
+	if !eh.buf.canEdit(userEdit) {
+		return
+	}
 	t := eh.RedoStack.Pop()
 	if t == nil {
 		return

--- a/internal/buffer/readonly_test.go
+++ b/internal/buffer/readonly_test.go
@@ -1,0 +1,329 @@
+package buffer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/micro-editor/micro/v2/internal/config"
+	ulua "github.com/micro-editor/micro/v2/internal/lua"
+	lua "github.com/yuin/gopher-lua"
+	luar "layeh.com/gopher-luar"
+)
+
+func TestReadonlyMutations(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Buffer)
+	}{
+		{"insert", func(b *Buffer) { b.Insert(b.Start(), "new") }},
+		{"remove", func(b *Buffer) { b.Remove(b.Start(), b.End()) }},
+		{"event insert", func(b *Buffer) { b.EventHandler.Insert(b.Start(), "new") }},
+		{"insert bytes", func(b *Buffer) { b.InsertBytes(b.Start(), []byte("new")) }},
+		{"event remove", func(b *Buffer) { b.EventHandler.Remove(b.Start(), b.End()) }},
+		{"raw insert", func(b *Buffer) { b.SharedBuffer.insert(b.Start(), []byte("new"), userEdit) }},
+		{"raw remove", func(b *Buffer) { b.SharedBuffer.remove(b.Start(), b.End(), userEdit) }},
+		{"replace", func(b *Buffer) { b.Replace(b.Start(), Loc{4, 0}, "// comment") }},
+		{"multiple replace", func(b *Buffer) { b.MultipleReplace([]Delta{{[]byte("new"), b.Start(), Loc{4, 0}}}) }},
+		{"regex replace", func(b *Buffer) { b.ReplaceRegex(b.Start(), b.End(), regexp.MustCompile("word"), []byte("new"), false) }},
+		{"diff", func(b *Buffer) { b.ApplyDiff("new\ntext") }},
+		{"retab", func(b *Buffer) { b.Settings["tabstospaces"] = true; b.Retab() }},
+		{"move lines up", func(b *Buffer) { b.MoveLinesUp(1, 2) }},
+		{"move lines down", func(b *Buffer) { b.MoveLinesDown(0, 1) }},
+		{"autocomplete", func(b *Buffer) {
+			b.Autocomplete(func(*Buffer) ([]string, []string) { return []string{"ing", "s"}, []string{"wording", "words"} })
+			b.CycleAutocomplete(true)
+		}},
+		{"write", func(b *Buffer) { b.Write([]byte("new")) }},
+	}
+	for _, typ := range []BufType{BTDefault, BTHelp, BTLog} {
+		for _, tt := range tests {
+			// Log writes are an explicitly supported internal update.
+			if typ == BTLog && tt.name == "write" {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/type%d", tt.name, typ.Kind), func(t *testing.T) {
+				b := NewBufferFromString("word\n\ttext", "", typ)
+				defer b.Close()
+				b.Type.Readonly = true
+				b.GetActiveCursor().GotoLoc(Loc{4, 0})
+				b.ModifiedThisFrame = false
+				cursor := *b.GetActiveCursor()
+				tt.edit(b)
+				if got := string(b.Bytes()); got != "word\n\ttext" {
+					t.Errorf("text changed: %q", got)
+				}
+				if b.UndoStack.Len() != 0 || b.RedoStack.Len() != 0 {
+					t.Error("history changed")
+				}
+				if !reflect.DeepEqual(cursor, *b.GetActiveCursor()) {
+					t.Error("cursor changed")
+				}
+				if b.Modified() || b.ModifiedThisFrame {
+					t.Error("buffer marked modified")
+				}
+			})
+		}
+	}
+}
+
+func TestReadonlySharedBuffer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "shared.txt")
+	b := NewBufferFromString("word", path, BTDefault)
+	defer b.Close()
+	other := NewBufferFromString("word", path, BTDefault)
+	defer other.Close()
+	if b.SharedBuffer != other.SharedBuffer {
+		t.Fatal("buffers are not shared")
+	}
+	if err := other.SetOptionNative("readonly", true); err != nil {
+		t.Fatal(err)
+	}
+	b.EventHandler.Replace(b.Start(), b.End(), "edit")
+	if string(other.Bytes()) != "word" || b.UndoStack.Len() != 0 {
+		t.Error("edit through another view bypassed readonly")
+	}
+	if err := other.SetOptionNative("readonly", false); err != nil {
+		t.Fatal(err)
+	}
+	b.EventHandler.Replace(b.Start(), b.End(), "edit")
+	if string(other.Bytes()) != "edit" {
+		t.Error("shared buffer remained read-only")
+	}
+}
+
+func TestReadonlyPluginEvents(t *testing.T) {
+	for _, mode := range []string{"readonly", "become readonly", "internal update", "save cleanup"} {
+		t.Run(mode, func(t *testing.T) {
+			initial := "word"
+			if mode == "save cleanup" {
+				initial = "word "
+			}
+			b := NewBufferFromString(initial, "", BTDefault)
+			defer b.Close()
+			b.Insert(b.End(), "!")
+			b.UndoOneEvent()
+			redo := b.RedoStack.Peek()
+			b.ModifiedThisFrame = false
+			cursor := *b.GetActiveCursor()
+			if mode == "internal update" {
+				b.Type = BTLog
+			} else {
+				b.Type.Readonly = mode == "readonly"
+			}
+
+			const name = "readonly_test_plugin"
+			oldPlugins := config.Plugins
+			oldGlobal := ulua.L.GetGlobal(name)
+			oldTarget := ulua.L.GetGlobal("readonly_test_target")
+			t.Cleanup(func() {
+				config.Plugins = oldPlugins
+				ulua.L.SetGlobal(name, oldGlobal)
+				ulua.L.SetGlobal("readonly_test_target", oldTarget)
+			})
+			ulua.L.SetGlobal("readonly_test_target", luar.New(ulua.L, b))
+			if err := ulua.L.DoString(`
+readonly_test_plugin = { calls = 0 }
+function readonly_test_plugin.onBeforeTextEvent(buf, event)
+    readonly_test_plugin.calls = readonly_test_plugin.calls + 1
+    buf.Type.Readonly = true
+    readonly_test_target:Insert(readonly_test_target:Start(), "plugin edit")
+    return true
+end
+`); err != nil {
+				t.Fatal(err)
+			}
+			config.Plugins = []*config.Plugin{{Name: name, Loaded: true}}
+			want, calls := initial, lua.LNumber(0)
+			if mode == "internal update" {
+				b.Write([]byte(" output"))
+				want, calls = "word output", 1
+			} else {
+				if mode == "save cleanup" {
+					b.Settings["rmtrailingws"] = true
+					b.Settings["eofnewline"] = true
+					// A directory destination stops the save before filesystem I/O.
+					if err := b.SaveAs(t.TempDir()); err == nil {
+						t.Fatal("saving to a directory succeeded")
+					}
+				} else {
+					b.Insert(b.Start(), "edit")
+				}
+				if mode == "become readonly" || mode == "save cleanup" {
+					calls = 1
+				}
+				if b.UndoStack.Len() != 0 || b.RedoStack.Peek() != redo {
+					t.Error("rejected event changed history")
+				}
+				if b.ModifiedThisFrame || !reflect.DeepEqual(cursor, *b.GetActiveCursor()) {
+					t.Error("rejected event changed modification state or cursor")
+				}
+			}
+			if got := string(b.Bytes()); got != want {
+				t.Errorf("text: got %q, want %q", got, want)
+			}
+			if got := ulua.L.GetField(ulua.L.GetGlobal(name), "calls"); got != calls {
+				t.Errorf("callback count: got %v, want %v", got, calls)
+			}
+			if !b.Type.Readonly {
+				t.Error("callback did not leave buffer read-only")
+			}
+		})
+	}
+}
+
+func TestMoveLinesUpPreservesEOFCursor(t *testing.T) {
+	b := NewBufferFromString("one\ntwo", "", BTDefault)
+	defer b.Close()
+	c := b.GetActiveCursor()
+	c.GotoLoc(Loc{3, 1})
+	c.SetSelectionStart(Loc{0, 1})
+	c.SetSelectionEnd(Loc{3, 1})
+	b.MoveLinesUp(1, 2)
+	if string(b.Bytes()) != "two\none\n" {
+		t.Fatal("lines did not move")
+	}
+	if c.Loc != (Loc{3, 0}) || c.CurSelection != ([2]Loc{{0, 0}, {3, 0}}) {
+		t.Errorf("cursor or selection moved away from text: %v, %v", c.Loc, c.CurSelection)
+	}
+}
+
+func TestReadonlyHistory(t *testing.T) {
+	for _, action := range []string{"undo", "redo", "undo one", "redo one", "insert", "replace"} {
+		t.Run(action, func(t *testing.T) {
+			b := NewBufferFromString("word", "", BTDefault)
+			defer b.Close()
+			b.Insert(b.End(), "!")
+			b.Insert(b.End(), "?")
+			b.UndoOneEvent()
+			undo, redo := b.UndoStack.Peek(), b.RedoStack.Peek()
+			undoCopy, redoCopy := *undo, *redo
+			cursor := *b.GetActiveCursor()
+			if err := b.SetOptionNative("readonly", true); err != nil {
+				t.Fatal(err)
+			}
+			switch action {
+			case "undo":
+				if b.Undo() {
+					t.Error("undo succeeded")
+				}
+			case "redo":
+				if b.Redo() {
+					t.Error("redo succeeded")
+				}
+			case "undo one":
+				b.UndoOneEvent()
+			case "redo one":
+				b.RedoOneEvent()
+			case "insert":
+				b.EventHandler.Insert(b.Start(), "new")
+			case "replace":
+				b.Replace(b.Start(), b.End(), "new")
+			}
+			if string(b.Bytes()) != "word!" || b.UndoStack.Len() != 1 || b.RedoStack.Len() != 1 {
+				t.Fatal("text or history changed")
+			}
+			if !reflect.DeepEqual(undoCopy, *undo) || !reflect.DeepEqual(redoCopy, *redo) || !reflect.DeepEqual(cursor, *b.GetActiveCursor()) {
+				t.Error("event or cursor changed")
+			}
+			if err := b.SetOptionNative("readonly", false); err != nil {
+				t.Fatal(err)
+			}
+			b.RedoOneEvent()
+			if string(b.Bytes()) != "word!?" {
+				t.Error("redo history lost")
+			}
+			b.UndoOneEvent()
+			b.UndoOneEvent()
+			if string(b.Bytes()) != "word" {
+				t.Error("undo history lost")
+			}
+		})
+	}
+}
+
+func TestReadonlyTextEvents(t *testing.T) {
+	for _, action := range []string{"execute", "do", "do without undo", "undo event", "raw"} {
+		t.Run(action, func(t *testing.T) {
+			b := NewBufferFromString("word", "", BTHelp)
+			defer b.Close()
+			event := &TextEvent{C: *b.GetActiveCursor(), EventType: TextEventRemove, Deltas: []Delta{{nil, b.Start(), b.End()}}, Time: time.Now()}
+			original := *event
+			original.Deltas = append([]Delta(nil), event.Deltas...)
+			switch action {
+			case "execute":
+				b.Execute(event)
+			case "do":
+				b.DoTextEvent(event, true)
+			case "do without undo":
+				b.DoTextEvent(event, false)
+			case "undo event":
+				b.UndoTextEvent(event)
+			case "raw":
+				ExecuteTextEvent(event, b.SharedBuffer)
+			}
+			if string(b.Bytes()) != "word" || !reflect.DeepEqual(original, *event) || b.UndoStack.Len() != 0 {
+				t.Error("rejected event changed text, history or event data")
+			}
+		})
+	}
+}
+
+func TestReadonlyInternalUpdates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "readonly.txt")
+	if err := os.WriteFile(path, []byte("new text"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBufferFromString("old text", path, BTDefault)
+	defer b.Close()
+	b.Type.Readonly = true
+	if err := b.ReOpen(); err != nil {
+		t.Fatal(err)
+	}
+	if string(b.Bytes()) != "new text" || !b.Type.Readonly || b.Modified() {
+		t.Error("reload failed to preserve read-only state")
+	}
+	b.Replace(b.Start(), b.End(), "edit")
+	if string(b.Bytes()) != "new text" {
+		t.Error("reload left buffer writable")
+	}
+	if n, err := b.Write([]byte("edit")); n != 0 || err == nil {
+		t.Error("read-only writer did not report rejection")
+	}
+
+	log := NewBufferFromString("", "", BTLog)
+	defer log.Close()
+	if n, err := log.Write([]byte("log output")); n != 10 || err != nil {
+		t.Fatalf("log write: %d, %v", n, err)
+	}
+	if string(log.Bytes()) != "log output" || !log.Type.Readonly {
+		t.Error("log output was blocked or buffer became writable")
+	}
+	log.Replace(log.Start(), log.End(), "edit")
+	if string(log.Bytes()) != "log output" {
+		t.Error("log write left buffer writable")
+	}
+}
+
+func TestRetabUndo(t *testing.T) {
+	b := NewBufferFromString("\tword\n    text", "", BTDefault)
+	defer b.Close()
+	b.Settings["tabstospaces"] = true
+	b.Settings["tabsize"] = float64(4)
+	b.Retab()
+	if string(b.Bytes()) != "    word\n    text" {
+		t.Fatal("retab failed")
+	}
+	b.UndoOneEvent()
+	if string(b.Bytes()) != "\tword\n    text" {
+		t.Fatal("retab was not undoable")
+	}
+	b.RedoOneEvent()
+	if string(b.Bytes()) != "    word\n    text" {
+		t.Fatal("retab redo failed")
+	}
+}

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -259,7 +259,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	if b.Settings["eofnewline"].(bool) {
 		end := b.End()
 		if b.RuneAt(Loc{end.X - 1, end.Y}) != '\n' {
-			b.insert(end, []byte{'\n'})
+			b.insert(end, []byte{'\n'}, userEdit)
 		}
 	}
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -330,6 +330,9 @@ Here are the available options:
 
 * `readonly`: when enabled, disallows edits to the buffer. It is recommended
    to only ever set this option locally using `setlocal`.
+   This includes undo/redo, replace, retab, autocomplete, and plugin edits.
+   Reloading from disk still updates the buffer. Log buffers still accept
+   log output. Rejected edits leave the undo/redo history unchanged.
 
     default value: `false`
 


### PR DESCRIPTION
Fixes micro-editor/micro#1805.

Read-only buffers currently accept edits through undo/redo, replace, retab, comments, and autocomplete. Enforce read-only state in the shared buffer and event layer, before changing text, event data, history, or cursors. Retab now uses undoable replacement events.

Reloads and log output use explicit internal permissions passed through private calls. The buffer stays read-only during plugin callbacks, so nested edits do not inherit that permission. Direct newline insertions for line moves and save cleanup obey the same guard.

Regression tests cover public and raw mutation paths, shared buffers, undo/redo preservation, autocomplete, Lua callbacks, reloads, log output, retab undo/redo, and cursor placement when moving the final line. The readonly help entry documents the behavior and internal exceptions.

Validation on Windows with Go 1.27.1:

- `go test ./... -count=1`
- Build of `./cmd/micro`
- Formatting and `git diff --check`

`go vet ./...` reports existing copylock and unkeyed struct literal warnings, also reproduced on upstream commit `393cf248`.
