### PR TITLE
Preserve minimum sizes in nested split layouts

### DIFF
--- a/cmd/micro/splits_test.go
+++ b/cmd/micro/splits_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/micro-editor/micro/v2/internal/action"
+	"github.com/micro-editor/micro/v2/internal/buffer"
+	"github.com/micro-editor/tcell/v2"
+)
+
+func TestNestedSplitMouseResize(t *testing.T) {
+	newBuffer := func(text string) *buffer.Buffer {
+		b := buffer.NewBufferFromString(text, "", buffer.BTDefault)
+		b.Settings["backup"] = false
+		t.Cleanup(b.Close)
+		return b
+	}
+	tab := action.NewTabFromBuffer(0, 0, 80, 24, newBuffer("first"))
+	first := tab.CurPane()
+	second := first.VSplitIndex(newBuffer("second"), true)
+	third := second.HSplitIndex(newBuffer("third"), true)
+	fourth := third.VSplitIndex(newBuffer("fourth"), true)
+	activeID := fourth.ID()
+	mouse := func(x, y int, button tcell.ButtonMask) {
+		tab.HandleEvent(tcell.NewEventMouse(x, y, button, tcell.ModNone, ""))
+	}
+
+	// Repeatedly drag the initial divider toward the right screen edge.
+	mouse(40, 0, tcell.Button1)
+	for x := 41; x < 80; x++ {
+		mouse(x, 0, tcell.Button1)
+		for _, p := range tab.Panes {
+			n := tab.GetNode(p.ID())
+			if n == nil || n.W < 1 || n.H < 1 {
+				t.Fatalf("mouse drag to %d lost pane %d", x, p.ID())
+			}
+		}
+	}
+	mouse(79, 0, tcell.ButtonNone)
+	if tab.CurPane().ID() != activeID || len(tab.Panes) != 4 {
+		t.Fatal("resize changed focus or pane membership")
+	}
+
+	// The nested divider still renders and can be selected with the mouse.
+	n := tab.GetNode(third.ID())
+	divider := buffer.Loc{X: n.X + n.W, Y: n.Y}
+	if tab.GetMouseSplitNode(divider) != n {
+		t.Fatal("nested divider is no longer reachable")
+	}
+	sim.Clear()
+	tab.UIWindow.Display()
+	if char, _, _, _ := sim.GetContent(divider.X, divider.Y); char != '|' {
+		t.Fatalf("nested divider is not visible: %q", char)
+	}
+
+	// Drag the parent back: all four panes regain their original width.
+	outer := tab.GetNode(first.ID())
+	mouse(outer.X+outer.W, 0, tcell.Button1)
+	mouse(40, 0, tcell.Button1)
+	mouse(40, 0, tcell.ButtonNone)
+	if tab.GetNode(third.ID()).W != 20 || tab.GetNode(fourth.ID()).W != 20 {
+		t.Fatal("nested panes did not recover their proportions")
+	}
+	if third.Buf.Line(0) != "third" || fourth.Buf.Line(0) != "fourth" {
+		t.Fatal("resize changed buffer contents")
+	}
+}

--- a/cmd/micro/splits_test.go
+++ b/cmd/micro/splits_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/micro-editor/micro/v2/internal/action"
@@ -63,5 +64,77 @@ func TestNestedSplitMouseResize(t *testing.T) {
 	}
 	if third.Buf.Line(0) != "third" || fourth.Buf.Line(0) != "fourth" {
 		t.Fatal("resize changed buffer contents")
+	}
+}
+
+func TestNestedSplitResizeKeepsTextVisible(t *testing.T) {
+	for _, softwrap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("softwrap=%v", softwrap), func(t *testing.T) {
+			newBuffer := func(text string) *buffer.Buffer {
+				b := buffer.NewBufferFromString(text, "", buffer.BTDefault)
+				b.Settings["backup"] = false
+				b.Settings["softwrap"] = softwrap
+				// Match text entered by the user: the cursor is at the end.
+				b.GetActiveCursor().GotoLoc(b.End())
+				t.Cleanup(b.Close)
+				return b
+			}
+			tab := action.NewTabFromBuffer(0, 0, 80, 24, newBuffer("first"))
+			first := tab.CurPane()
+			second := first.VSplitIndex(newBuffer("second"), true)
+			third := second.HSplitIndex(newBuffer("third"), true)
+			fourth := third.VSplitIndex(newBuffer("fourth"), true)
+			panes := []*action.BufPane{first, second, third, fourth}
+			texts := []string{"first", "second", "third", "fourth"}
+			draw := func() {
+				sim.Clear()
+				for _, p := range panes {
+					p.Display()
+				}
+				tab.UIWindow.Display()
+			}
+			checkText := func() {
+				t.Helper()
+				draw()
+				for i, p := range panes {
+					if string(p.Buf.Bytes()) != texts[i] {
+						t.Fatalf("pane %d buffer contents changed: %q", i, p.Buf.Bytes())
+					}
+					v := p.BufView()
+					var visible []rune
+					for x := 0; x < len(texts[i]); x++ {
+						char, _, _, _ := sim.GetContent(v.X+x, v.Y)
+						visible = append(visible, char)
+					}
+					if string(visible) != texts[i] {
+						t.Errorf("pane %d text is not visible: got %q, want %q; view=%+v cursor=%v", i, string(visible), texts[i], v, p.Cursor.Loc)
+					}
+				}
+			}
+			checkText()
+			mouse := func(x int, button tcell.ButtonMask) {
+				tab.HandleEvent(tcell.NewEventMouse(x, 0, button, tcell.ModNone, ""))
+				draw()
+			}
+			// Shrink the right panes and then the first pane, restoring the
+			// original divider position after each drag.
+			for _, target := range []int{78, 40, 1, 40} {
+				outer := tab.GetNode(first.ID())
+				position := outer.X + outer.W
+				mouse(position, tcell.Button1)
+				step := 1
+				if target < position {
+					step = -1
+				}
+				for position != target {
+					position += step
+					mouse(position, tcell.Button1)
+				}
+				mouse(position, tcell.ButtonNone)
+				if target == 40 {
+					checkText()
+				}
+			}
+		})
 	}
 }

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -86,9 +86,15 @@ func (w *BufWindow) SetView(view *View) {
 
 // Resize resizes this window.
 func (w *BufWindow) Resize(width, height int) {
+	oldWidth := w.bufWidth
 	w.Width, w.Height = width, height
 	w.updateDisplayInfo()
 
+	// Reveal text scrolled out while the pane was narrower. Relocate alone
+	// keeps the cursor visible but can leave the view at the end of the line.
+	if !w.Buf.Settings["softwrap"].(bool) && w.bufWidth > oldWidth {
+		w.StartCol = util.Max(0, w.StartCol-(w.bufWidth-oldWidth))
+	}
 	w.Relocate()
 }
 

--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -140,6 +140,29 @@ func (n *Node) GetNode(id uint64) *Node {
 	return nil
 }
 
+// minimumSize reserves a cell for each leaf, including its divider or status
+// line. Siblings share the cross axis and add up along the split axis.
+func (n *Node) minimumSize() (w, h int) {
+	if n.IsLeaf() {
+		return 1, 1
+	}
+	for _, c := range n.children {
+		cw, ch := c.minimumSize()
+		if n.Kind == STHoriz {
+			w += cw
+			if ch > h {
+				h = ch
+			}
+		} else {
+			h += ch
+			if cw > w {
+				w = cw
+			}
+		}
+	}
+	return
+}
+
 func (n *Node) vResizeSplit(i int, size int) bool {
 	if i < 0 || i >= len(n.children) {
 		return false
@@ -151,14 +174,15 @@ func (n *Node) vResizeSplit(i int, size int) bool {
 		c1, c2 = n.children[i], n.children[i+1]
 	}
 	toth := c1.H + c2.H
-	if size >= toth {
+	_, min1 := c1.minimumSize()
+	_, min2 := c2.minimumSize()
+	if size < min1 || toth-size < min2 {
 		return false
 	}
 	c2.Y = c1.Y + size
 	c1.Resize(c1.W, size)
 	c2.Resize(c2.W, toth-size)
 	n.markSizes()
-	n.alignSizes(n.W, n.H)
 	return true
 }
 func (n *Node) hResizeSplit(i int, size int) bool {
@@ -172,14 +196,15 @@ func (n *Node) hResizeSplit(i int, size int) bool {
 		c1, c2 = n.children[i], n.children[i+1]
 	}
 	totw := c1.W + c2.W
-	if size >= totw {
+	min1, _ := c1.minimumSize()
+	min2, _ := c2.minimumSize()
+	if size < min1 || totw-size < min2 {
 		return false
 	}
 	c2.X = c1.X + size
 	c1.Resize(size, c1.H)
 	c2.Resize(totw-size, c2.H)
 	n.markSizes()
-	n.alignSizes(n.W, n.H)
 	return true
 }
 
@@ -205,58 +230,105 @@ func (n *Node) ResizeSplit(size int) bool {
 	return n.parent.hResizeSplit(ind, size)
 }
 
-// Resize sets this node's size and resizes all children accordingly
+// Resize sets this node's size and resizes all children accordingly.
+// If the terminal is too small to fit the tree, retain the minimum layout
+// without losing the proportions needed when the terminal grows again.
 func (n *Node) Resize(w, h int) {
+	minw, minh := n.minimumSize()
+	if w < minw {
+		w = minw
+	}
+	if h < minh {
+		h = minh
+	}
 	n.W, n.H = w, h
 
 	if n.IsLeaf() {
 		return
 	}
 
-	x, y := n.X, n.Y
-	totw, toth := 0, 0
-	for _, c := range n.children {
-		cW := int(float64(w) * c.propW)
-		cH := int(float64(h) * c.propH)
-
-		c.X, c.Y = x, y
-		c.Resize(cW, cH)
+	minimums := make([]int, len(n.children))
+	remainingMin := 0
+	for i, c := range n.children {
+		cw, ch := c.minimumSize()
+		minimums[i] = ch
 		if n.Kind == STHoriz {
-			x += cW
-			totw += cW
+			minimums[i] = cw
+		}
+		remainingMin += minimums[i]
+	}
+
+	size := h
+	if n.Kind == STHoriz {
+		size = w
+	}
+	remaining := size
+	x, y := n.X, n.Y
+	for i, c := range n.children {
+		proportion := c.propH
+		if n.Kind == STHoriz {
+			proportion = c.propW
+		}
+		childSize := int(float64(size) * proportion)
+		remainingMin -= minimums[i]
+		if childSize < minimums[i] {
+			childSize = minimums[i]
+		}
+		// Reserve enough room for every following subtree. The last child
+		// receives the rounding remainder, which can never erase a sibling.
+		if childSize > remaining-remainingMin || i == len(n.children)-1 {
+			childSize = remaining - remainingMin
+		}
+		c.X, c.Y = x, y
+		if n.Kind == STHoriz {
+			c.Resize(childSize, h)
+			x += childSize
 		} else {
-			y += cH
-			toth += cH
+			c.Resize(w, childSize)
+			y += childSize
+		}
+		remaining -= childSize
+	}
+}
+
+// Record the proportions of direct children after a local layout change.
+// Descendant proportions must survive rounding during ancestor resizes.
+func (n *Node) markSizes() {
+	total := 0
+	for _, c := range n.children {
+		if n.Kind == STHoriz {
+			total += c.W
+		} else {
+			total += c.H
 		}
 	}
-
-	n.alignSizes(totw, toth)
-}
-
-func (n *Node) alignSizes(totw, toth int) {
-	// Make sure that there are no off-by-one problems with the rounding
-	// of the sizes by making the final split fill the screen
-	if n.Kind == STVert && toth != n.H {
-		last := n.children[len(n.children)-1]
-		last.Resize(last.W, last.H+n.H-toth)
-	} else if n.Kind == STHoriz && totw != n.W {
-		last := n.children[len(n.children)-1]
-		last.Resize(last.W+n.W-totw, last.H)
-	}
-}
-
-// Resets all proportions for children
-func (n *Node) markSizes() {
 	for _, c := range n.children {
-		c.propW = float64(c.W) / float64(n.W)
-		c.propH = float64(c.H) / float64(n.H)
-		c.markSizes()
+		// New siblings may not yet fit their parent. Normalize their intended
+		// sizes, including equal shares when splitting a one-cell pane.
+		proportion := 1 / float64(len(n.children))
+		if total > 0 {
+			size := c.H
+			if n.Kind == STHoriz {
+				size = c.W
+			}
+			proportion = float64(size) / float64(total)
+		}
+		c.propW, c.propH = 1, proportion
+		if n.Kind == STHoriz {
+			c.propW, c.propH = proportion, 1
+		}
 	}
 }
 
 func (n *Node) markResize() {
 	n.markSizes()
-	n.Resize(n.W, n.H)
+	// A new split can increase this subtree's minimum size. Relayout from
+	// the root so its ancestors can take the needed space from siblings.
+	root := n
+	for root.parent != nil {
+		root = root.parent
+	}
+	root.Resize(root.W, root.H)
 }
 
 // vsplits a vertical split and returns the id of the new split

--- a/internal/views/splits_resize_test.go
+++ b/internal/views/splits_resize_test.go
@@ -1,0 +1,240 @@
+package views
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// nestedSplits reproduces #3071: vsplit, hsplit, vsplit. Transposing the
+// layout exercises the corresponding horizontal divider behavior.
+func nestedSplits(transpose, nestedFirst bool) *Node {
+	root := NewRoot(0, 0, 80, 80)
+	first := root.ID()
+	split := func(n *Node, vertical bool) uint64 {
+		if vertical != transpose {
+			return n.VSplit(true)
+		}
+		return n.HSplit(true)
+	}
+	nested := split(root, true)
+	if nestedFirst {
+		nested = first
+	}
+	last := split(root.GetNode(nested), false)
+	split(root.GetNode(last), true)
+	return root
+}
+
+func checkSplitLayout(t *testing.T, n *Node) {
+	t.Helper()
+	if n.W < 1 || n.H < 1 {
+		t.Fatalf("collapsed node: %v\n%s", n.View, n)
+	}
+	x, y := n.X, n.Y
+	for _, c := range n.children {
+		if c.parent != n || c.X != x || c.Y != y {
+			t.Fatalf("incorrect parent or position: child %v, expected (%d,%d)\n%s", c.View, x, y, n)
+		}
+		if n.Kind == STHoriz {
+			if c.H != n.H {
+				t.Fatalf("child does not fill parent height: %v in %v", c.View, n.View)
+			}
+			x += c.W
+		} else {
+			if c.W != n.W {
+				t.Fatalf("child does not fill parent width: %v in %v", c.View, n.View)
+			}
+			y += c.H
+		}
+		checkSplitLayout(t, c)
+	}
+	if !n.IsLeaf() && ((n.Kind == STHoriz && x != n.X+n.W) || (n.Kind == STVert && y != n.Y+n.H)) {
+		t.Fatalf("children do not tile their parent\n%s", n)
+	}
+}
+
+type splitState struct {
+	view         View
+	propW, propH float64
+	id           uint64
+}
+
+func splitSnapshot(n *Node) []splitState {
+	result := []splitState{{n.View, n.propW, n.propH, n.id}}
+	for _, c := range n.children {
+		result = append(result, splitSnapshot(c)...)
+	}
+	return result
+}
+
+func TestNestedResizeSplitMinimum(t *testing.T) {
+	for _, transpose := range []bool{false, true} {
+		for _, nestedFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("transpose=%v/nestedFirst=%v", transpose, nestedFirst), func(t *testing.T) {
+				root := nestedSplits(transpose, nestedFirst)
+				// The nested subtree needs two cells along the resize axis.
+				min, max := 1, 78
+				if nestedFirst {
+					min, max = 2, 79
+				}
+				for size := -1; size <= 81; size++ {
+					before := splitSnapshot(root)
+					want := size >= min && size <= max
+					if got := root.children[0].ResizeSplit(size); got != want {
+						t.Fatalf("ResizeSplit(%d) = %v, want %v", size, got, want)
+					}
+					if !want && !reflect.DeepEqual(before, splitSnapshot(root)) {
+						t.Fatalf("rejected resize %d changed the tree", size)
+					}
+					checkSplitLayout(t, root)
+				}
+				for size := max; size >= min; size-- {
+					if !root.children[0].ResizeSplit(size) {
+						t.Fatalf("valid resize %d rejected", size)
+					}
+					checkSplitLayout(t, root)
+				}
+			})
+		}
+	}
+}
+
+func TestNestedResizePreservesProportions(t *testing.T) {
+	for _, transpose := range []bool{false, true} {
+		t.Run(fmt.Sprint(transpose), func(t *testing.T) {
+			root := nestedSplits(transpose, false)
+			before := splitSnapshot(root)
+			for cycle := 0; cycle < 3; cycle++ {
+				for size := 41; size <= 65; size++ {
+					root.children[0].ResizeSplit(size)
+				}
+				for size := 64; size >= 40; size-- {
+					root.children[0].ResizeSplit(size)
+				}
+				if !reflect.DeepEqual(before, splitSnapshot(root)) {
+					t.Fatalf("dragging changed descendant proportions\n%s", root)
+				}
+			}
+		})
+	}
+}
+
+func TestResizeReservesDescendantSpace(t *testing.T) {
+	for _, transpose := range []bool{false, true} {
+		t.Run(fmt.Sprint(transpose), func(t *testing.T) {
+			root := nestedSplits(transpose, false)
+			nested := root.children[1].children[1]
+			// A narrow first child must retain a cell even when its proportional
+			// share rounds down to zero after resizing an ancestor.
+			if !nested.children[0].ResizeSplit(1) {
+				t.Fatal("initial resize failed")
+			}
+			if !root.children[0].ResizeSplit(78) {
+				t.Fatal("minimum-size subtree was rejected")
+			}
+			checkSplitLayout(t, root)
+			if transpose {
+				if nested.children[0].H != 1 || nested.children[1].H != 1 {
+					t.Fatal("minimum heights not respected")
+				}
+			} else if nested.children[0].W != 1 || nested.children[1].W != 1 {
+				t.Fatal("minimum widths not respected")
+			}
+		})
+	}
+}
+
+func TestResizeWholeTreeMinimumAndRecovery(t *testing.T) {
+	for _, transpose := range []bool{false, true} {
+		t.Run(fmt.Sprint(transpose), func(t *testing.T) {
+			root := nestedSplits(transpose, false)
+			before := splitSnapshot(root)
+			for _, size := range []int{79, 25, 3, 1, 0, -1} {
+				root.Resize(size, size)
+				checkSplitLayout(t, root)
+			}
+			// Smaller terminals cannot fit all panes: keep the minimum layout
+			// intact, and recover its proportions when space becomes available.
+			wantW, wantH := 3, 2
+			if transpose {
+				wantW, wantH = 2, 3
+			}
+			if root.W != wantW || root.H != wantH {
+				t.Fatalf("minimum root size: got %dx%d, want %dx%d", root.W, root.H, wantW, wantH)
+			}
+			root.Resize(80, 80)
+			if !reflect.DeepEqual(before, splitSnapshot(root)) {
+				t.Fatal("window resize lost original proportions")
+			}
+		})
+	}
+}
+
+func TestResizeThreeDescendants(t *testing.T) {
+	root := nestedSplits(false, false)
+	nested := root.children[1].children[1]
+	nested.children[0].VSplit(false)
+	if !root.children[0].ResizeSplit(77) {
+		t.Fatal("three-cell subtree rejected")
+	}
+	checkSplitLayout(t, root)
+	before := splitSnapshot(root)
+	if root.children[0].ResizeSplit(78) {
+		t.Fatal("allowed three children in two cells")
+	}
+	if !reflect.DeepEqual(before, splitSnapshot(root)) {
+		t.Fatal("rejected resize changed layout")
+	}
+	// Closing a pane must still flatten the tree and leave it resizable.
+	id := nested.children[0].ID()
+	if !root.GetNode(id).Unsplit() {
+		t.Fatal("closing pane failed")
+	}
+	checkSplitLayout(t, root)
+	root.Resize(81, 79)
+	checkSplitLayout(t, root)
+}
+
+func TestSplitAtMinimumRelayoutsAncestors(t *testing.T) {
+	for _, transpose := range []bool{false, true} {
+		t.Run(fmt.Sprint(transpose), func(t *testing.T) {
+			root := NewRoot(0, 0, 80, 80)
+			var right, bottom uint64
+			if transpose {
+				right = root.HSplit(true)
+				bottom = root.GetNode(right).VSplit(true)
+			} else {
+				right = root.VSplit(true)
+				bottom = root.GetNode(right).HSplit(true)
+			}
+			if !root.children[0].ResizeSplit(79) {
+				t.Fatal("initial resize failed")
+			}
+			var last uint64
+			if transpose {
+				last = root.GetNode(bottom).HSplit(true)
+			} else {
+				last = root.GetNode(bottom).VSplit(true)
+			}
+			if root.GetNode(last) == nil {
+				t.Fatal("new pane missing")
+			}
+			checkSplitLayout(t, root)
+			if root.W != 80 || root.H != 80 {
+				t.Fatal("layout grew despite available space in the root")
+			}
+			if !root.children[0].ResizeSplit(40) {
+				t.Fatal("restoring outer size failed")
+			}
+			first, second := root.GetNode(bottom), root.GetNode(last)
+			if transpose {
+				if first.H != 20 || second.H != 20 {
+					t.Fatal("new horizontal splits lost equal proportions")
+				}
+			} else if first.W != 20 || second.W != 20 {
+				t.Fatal("new vertical splits lost equal proportions")
+			}
+		})
+	}
+}

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -93,6 +93,10 @@ quotes here but these are not necessary when entering the command in micro.
    is provided, a vertical split is opened with an empty buffer. If multiple
    files are provided (separated via ` `) they are opened all as splits.
 
+   Drag a divider to resize splits. Resizing keeps room for nested dividers,
+   even when the pane content no longer fits. Enlarging the split restores
+   its nested panes' proportions.
+
 * `hsplit ['filename']`: same as `vsplit` but opens a horizontal split instead
    of a vertical split.
 


### PR DESCRIPTION
Fixes micro-editor/micro#3071.

After `vsplit`, `hsplit`, `vsplit`, repeatedly dragging the outer divider can shrink an inner pane to zero width. Its buffer remains open and can retain focus, but its divider disappears.

Calculate minimum dimensions recursively in the layout tree and reject divider moves that cannot fit both neighboring subtrees. Allocate at least one layout cell per leaf, reserving space for its divider or status line. Keep descendants' proportions when resizing ancestors so rounding does not accumulate on each mouse movement.

Adding a split inside a minimal pane now relayouts the root so ancestors can make room. Sibling proportions are normalized, including equal shares when splitting a one-cell pane. If the terminal itself is smaller than the minimum layout, the layout may be clipped; its dimensions stay positive and its proportions recover when the terminal grows.

When a pane widens, its horizontal view scrolls back to reveal text hidden while it was narrow. Without this adjustment, a cursor at the end of a line could leave a blank viewport after widening, even though the buffer still contained the text.

Tests cover both resize orientations, nested panes on either side, rejected resize state, asymmetric proportions, three descendants, closing panes, terminal shrink/recovery, and splitting a minimal pane. A simulated mouse test follows the issue's reproduction and checks pane identity, focus, a rendered and clickable nested divider, and restored widths after dragging back.

A second mouse test keeps the cursor at the end of the entered text and checks the rendered text in all four panes after shrinking and widening both sides, with softwrap enabled and disabled.

Validation on Windows with Go 1.27.1:

- `go test ./... -count=1`
- Build of `./cmd/micro`
- Formatting and `git diff --check`

The one-cell minimum follows the discussion's requirement that dividers remain accessible even when pane content no longer fits.
