### PR TITLE
dupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ If you use micro within WSL, it is highly recommended that you use the [Windows
 Terminal](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701?hl=en-us&gl=us)
 instead of the default Windows Console.
 
+In Windows Terminal, you can also press `Ctrl-e` and run `set clipboard terminal`
+to copy through the terminal using OSC 52. This avoids searching the WSL/Windows
+`PATH` for clipboard tools and launching PowerShell. Paste with Windows Terminal's
+paste shortcut if your terminal does not support reading the clipboard via OSC 52.
+
 If you must use Windows Console for some reason, note that there is a bug in
 Windows Console WSL that causes a font change whenever micro tries to access
 the external clipboard via powershell. To fix this, use an internal clipboard

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -383,7 +383,7 @@ func main() {
 	signal.Notify(sighup, syscall.SIGHUP)
 
 	m := clipboard.SetMethod(config.GetGlobalOption("clipboard").(string))
-	clipErr := clipboard.Initialize(m)
+	clipboard.InitAsync(m)
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -452,10 +452,6 @@ func main() {
 	err = config.InitColorscheme()
 	if err != nil {
 		screen.TermMessage(err)
-	}
-
-	if clipErr != nil {
-		log.Println(clipErr, " or change 'clipboard' option")
 	}
 
 	config.StartAutoSave()

--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,6 @@ replace github.com/kballard/go-shellquote => github.com/micro-editor/go-shellquo
 replace layeh.com/gopher-luar v1.0.11 => github.com/layeh/gopher-luar v1.0.11
 
 go 1.19
+
+// Pending https://github.com/zyedidia/clipper/pull/6; use an upstream revision after merge.
+replace github.com/zyedidia/clipper => github.com/frankischilling/clipper v0.1.2-0.20260908202249-3095b365e472

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/frankischilling/clipper v0.1.2-0.20260908202249-3095b365e472 h1:cZSjj8ZEpT9nPm3rMLfND9qUI/qP4wZtf92eL4NNCco=
+github.com/frankischilling/clipper v0.1.2-0.20260908202249-3095b365e472/go.mod h1:7YApPNiiTZTXdKKZG92G50qj6mnWEX975Sdu65J7YpQ=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
@@ -51,8 +53,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/yuin/gopher-lua v0.0.0-20190206043414-8bfc7677f583/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
-github.com/zyedidia/clipper v0.1.1 h1:HBgguFNDq/QmSQKBnhy4sMKzILINr139VEgAhftOUTw=
-github.com/zyedidia/clipper v0.1.1/go.mod h1:7YApPNiiTZTXdKKZG92G50qj6mnWEX975Sdu65J7YpQ=
 github.com/zyedidia/glob v0.0.0-20170209203856-dd4023a66dc3 h1:oMHjjTLfGXVuyOQBYj5/td9WC0mw4g1xDBPovIqmHew=
 github.com/zyedidia/glob v0.0.0-20170209203856-dd4023a66dc3/go.mod h1:YKbIYP//Eln8eDgAJGI3IDvR3s4Tv9Z9TGIOumiyQ5c=
 github.com/zyedidia/poller v1.0.1 h1:Tt9S3AxAjXwWGNiC2TUdRJkQDZSzCBNVQ4xXiQ7440s=

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -2,6 +2,7 @@ package clipboard
 
 import (
 	"errors"
+	"log"
 
 	"github.com/zyedidia/clipper"
 )
@@ -21,7 +22,8 @@ const (
 	Internal
 )
 
-// CurrentMethod is the method used to store clipboard information
+// CurrentMethod is the selected clipboard method. External falls back to internal
+// storage if no system clipboard is available.
 var CurrentMethod Method = Internal
 
 // A Register is a buffer used to store text. The system clipboard has the 'clipboard'
@@ -35,24 +37,68 @@ const (
 	PrimaryReg = -2
 )
 
-var clipboard clipper.Clipboard
+// Each detection attempt owns its result. The worker never changes the selected
+// method, and readers must wait for done before accessing clipboard or err.
+type clipboardDetection struct {
+	done      chan struct{}
+	clipboard clipper.Clipboard
+	err       error
+}
 
-// Initialize attempts to initialize the clipboard using the given method
+var external *clipboardDetection
+
+// detect starts a probe or reuses the current result. Explicit initialization
+// refreshes completed probes so changes to installed tools can be picked up.
+// Like the clipboard registers and selected method, external is owned by the
+// editor goroutine; only the result inside a detection is written by its worker.
+func detect(refresh bool) *clipboardDetection {
+	if external != nil {
+		select {
+		case <-external.done:
+			if !refresh {
+				return external
+			}
+		default:
+			return external
+		}
+	}
+
+	clips := make([]clipper.Clipboard, 0, len(clipper.Clipboards)+1)
+	clips = append(clips, &clipper.Custom{Name: "micro-clip"})
+	clips = append(clips, clipper.Clipboards...)
+	d := &clipboardDetection{done: make(chan struct{})}
+	external = d
+	go func() {
+		d.clipboard, d.err = clipper.GetClipboard(clips...)
+		close(d.done)
+	}()
+	return d
+}
+
+// Initialize waits for clipboard detection using the given method. A completed
+// external probe is refreshed; a probe already in progress is shared.
 func Initialize(m Method) error {
-	var err error
-	switch m {
-	case External:
-		clips := make([]clipper.Clipboard, 0, len(clipper.Clipboards)+1)
-		clips = append(clips, &clipper.Custom{
-			Name: "micro-clip",
-		})
-		clips = append(clips, clipper.Clipboards...)
-		clipboard, err = clipper.GetClipboard(clips...)
+	if m != External {
+		return nil
 	}
-	if err != nil {
-		CurrentMethod = Internal
+	d := detect(true)
+	<-d.done
+	return d.err
+}
+
+// InitAsync starts clipboard detection without waiting, logging any failure.
+// Only external system clipboard operations need to wait for the result.
+func InitAsync(m Method) {
+	if m != External {
+		return
 	}
-	return err
+	d := detect(false)
+	go func() {
+		<-d.done
+		if d.err != nil {
+			log.Println(d.err, " or change 'clipboard' option")
+		}
+	}()
 }
 
 // SetMethod changes the clipboard access method
@@ -109,15 +155,21 @@ func writeMulti(text string, r Register, num int, ncursors int, m Method) error 
 func read(r Register, m Method) (string, error) {
 	switch m {
 	case External:
+		if r != ClipboardReg && r != PrimaryReg {
+			return internal.read(r), nil
+		}
+		d := detect(false)
+		<-d.done
+		if d.err != nil {
+			return internal.read(r), nil
+		}
 		switch r {
 		case ClipboardReg:
-			b, e := clipboard.ReadAll(clipper.RegClipboard)
+			b, e := d.clipboard.ReadAll(clipper.RegClipboard)
 			return string(b), e
 		case PrimaryReg:
-			b, e := clipboard.ReadAll(clipper.RegPrimary)
+			b, e := d.clipboard.ReadAll(clipper.RegPrimary)
 			return string(b), e
-		default:
-			return internal.read(r), nil
 		}
 	case Internal:
 		return internal.read(r), nil
@@ -139,13 +191,21 @@ func read(r Register, m Method) (string, error) {
 func write(text string, r Register, m Method) error {
 	switch m {
 	case External:
+		if r != ClipboardReg && r != PrimaryReg {
+			internal.write(text, r)
+			return nil
+		}
+		d := detect(false)
+		<-d.done
+		if d.err != nil {
+			internal.write(text, r)
+			return nil
+		}
 		switch r {
 		case ClipboardReg:
-			return clipboard.WriteAll(clipper.RegClipboard, []byte(text))
+			return d.clipboard.WriteAll(clipper.RegClipboard, []byte(text))
 		case PrimaryReg:
-			return clipboard.WriteAll(clipper.RegPrimary, []byte(text))
-		default:
-			internal.write(text, r)
+			return d.clipboard.WriteAll(clipper.RegPrimary, []byte(text))
 		}
 	case Internal:
 		internal.write(text, r)

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -37,68 +37,47 @@ const (
 	PrimaryReg = -2
 )
 
-// Each detection attempt owns its result. The worker never changes the selected
-// method, and readers must wait for done before accessing clipboard or err.
-type clipboardDetection struct {
-	done      chan struct{}
-	clipboard clipper.Clipboard
-	err       error
-}
+var clipboard clipper.Clipboard
 
-var external *clipboardDetection
-
-// detect starts a probe or reuses the current result. Explicit initialization
-// refreshes completed probes so changes to installed tools can be picked up.
-// Like the clipboard registers and selected method, external is owned by the
-// editor goroutine; only the result inside a detection is written by its worker.
-func detect(refresh bool) *clipboardDetection {
-	if external != nil {
-		select {
-		case <-external.done:
-			if !refresh {
-				return external
-			}
-		default:
-			return external
-		}
-	}
-
-	clips := make([]clipper.Clipboard, 0, len(clipper.Clipboards)+1)
-	clips = append(clips, &clipper.Custom{Name: "micro-clip"})
-	clips = append(clips, clipper.Clipboards...)
-	d := &clipboardDetection{done: make(chan struct{})}
-	external = d
-	go func() {
-		d.clipboard, d.err = clipper.GetClipboard(clips...)
-		close(d.done)
-	}()
-	return d
-}
-
-// Initialize waits for clipboard detection using the given method. A completed
-// external probe is refreshed; a probe already in progress is shared.
+// Initialize refreshes clipboard detection using the given method and waits
+// for the result.
 func Initialize(m Method) error {
 	if m != External {
 		return nil
 	}
-	d := detect(true)
-	<-d.done
-	return d.err
+	if clipboard != nil {
+		// Finish any pending detection before reusing its backend objects.
+		clipboard.Init()
+	}
+	clipboard = nil
+	InitAsync(m)
+	err := clipboard.Init()
+	if err != nil && CurrentMethod == External {
+		CurrentMethod = Internal
+	}
+	return err
 }
 
-// InitAsync starts clipboard detection without waiting, logging any failure.
+// InitAsync starts clipboard detection without waiting.
 // Only external system clipboard operations need to wait for the result.
 func InitAsync(m Method) {
-	if m != External {
+	if m != External || clipboard != nil {
 		return
 	}
-	d := detect(false)
-	go func() {
-		<-d.done
-		if d.err != nil {
-			log.Println(d.err, " or change 'clipboard' option")
-		}
-	}()
+	clips := make([]clipper.Clipboard, 0, len(clipper.Clipboards)+1)
+	clips = append(clips, &clipper.Custom{Name: "micro-clip"})
+	clips = append(clips, clipper.Clipboards...)
+	clipboard = clipper.GetClipboardAsync(clips...)
+}
+
+func externalReady() bool {
+	InitAsync(External)
+	if err := clipboard.Init(); err != nil {
+		log.Println(err, " or change 'clipboard' option")
+		CurrentMethod = Internal
+		return false
+	}
+	return true
 }
 
 // SetMethod changes the clipboard access method
@@ -158,17 +137,15 @@ func read(r Register, m Method) (string, error) {
 		if r != ClipboardReg && r != PrimaryReg {
 			return internal.read(r), nil
 		}
-		d := detect(false)
-		<-d.done
-		if d.err != nil {
+		if !externalReady() {
 			return internal.read(r), nil
 		}
 		switch r {
 		case ClipboardReg:
-			b, e := d.clipboard.ReadAll(clipper.RegClipboard)
+			b, e := clipboard.ReadAll(clipper.RegClipboard)
 			return string(b), e
 		case PrimaryReg:
-			b, e := d.clipboard.ReadAll(clipper.RegPrimary)
+			b, e := clipboard.ReadAll(clipper.RegPrimary)
 			return string(b), e
 		}
 	case Internal:
@@ -195,17 +172,15 @@ func write(text string, r Register, m Method) error {
 			internal.write(text, r)
 			return nil
 		}
-		d := detect(false)
-		<-d.done
-		if d.err != nil {
+		if !externalReady() {
 			internal.write(text, r)
 			return nil
 		}
 		switch r {
 		case ClipboardReg:
-			return d.clipboard.WriteAll(clipper.RegClipboard, []byte(text))
+			return clipboard.WriteAll(clipper.RegClipboard, []byte(text))
 		case PrimaryReg:
-			return d.clipboard.WriteAll(clipper.RegPrimary, []byte(text))
+			return clipboard.WriteAll(clipper.RegPrimary, []byte(text))
 		}
 	case Internal:
 		internal.write(text, r)

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,361 @@
+package clipboard
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/micro-editor/micro/v2/internal/screen"
+	"github.com/micro-editor/tcell/v2"
+	"github.com/zyedidia/clipper"
+)
+
+// controlledClipboard keeps tests independent of installed clipboard tools and
+// lets them hold detection open without launching a real clipboard command.
+type controlledClipboard struct {
+	started chan struct{}
+	release chan struct{}
+	err     error
+	text    map[string][]byte
+}
+
+func (c *controlledClipboard) Init() error {
+	c.started <- struct{}{}
+	<-c.release
+	return c.err
+}
+
+func (c *controlledClipboard) ReadAll(reg string) ([]byte, error) {
+	return c.text[reg], nil
+}
+
+func (c *controlledClipboard) WriteAll(reg string, text []byte) error {
+	c.text[reg] = text
+	return nil
+}
+
+func setupClipboard(t *testing.T) *controlledClipboard {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+	savedClips, savedExternal, savedMethod := clipper.Clipboards, external, CurrentMethod
+	savedInternal, savedMulti := internal, multi
+	c := &controlledClipboard{
+		started: make(chan struct{}, 10),
+		release: make(chan struct{}),
+		text:    make(map[string][]byte),
+	}
+	clipper.Clipboards = []clipper.Clipboard{c}
+	external = nil
+	internal = make(internalClipboard)
+	multi = make(multiClipboard)
+	t.Cleanup(func() {
+		c.finish()
+		if external != nil {
+			waitFor(t, external.done, "clipboard cleanup")
+		}
+		clipper.Clipboards, external, CurrentMethod = savedClips, savedExternal, savedMethod
+		internal, multi = savedInternal, savedMulti
+	})
+	return c
+}
+
+func (c *controlledClipboard) finish() {
+	select {
+	case <-c.release:
+	default:
+		close(c.release)
+	}
+}
+
+func waitFor(t *testing.T, ch <-chan struct{}, operation string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+func TestInitializeFailurePreservesSelectedMethod(t *testing.T) {
+	c := setupClipboard(t)
+	c.err = errors.New("clipboard unavailable")
+	SetMethod("external")
+	done := make(chan struct{})
+	var initErr error
+	go func() {
+		initErr = Initialize(External)
+		close(done)
+	}()
+	waitFor(t, c.started, "clipboard detection")
+	SetMethod("terminal")
+	if err := Initialize(Terminal); err != nil {
+		t.Fatal(err)
+	}
+	close(c.release)
+	waitFor(t, done, "failed clipboard detection")
+	if initErr == nil {
+		t.Fatal("external initialization should fail")
+	}
+	if CurrentMethod != Terminal {
+		t.Fatalf("failed external detection changed selected method to %v; want Terminal", CurrentMethod)
+	}
+}
+
+// A timeout is only a deadlock guard: the probe stays blocked until the test
+// explicitly releases it, regardless of the speed of the machine running it.
+func beforeDetectionFinishes(t *testing.T, c *controlledClipboard, operation func() error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- operation() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		c.finish()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("operation did not finish after releasing detection")
+		}
+		t.Fatal("operation waited for external clipboard detection")
+	}
+}
+
+func startBlockedDetection(t *testing.T, c *controlledClipboard) {
+	t.Helper()
+	SetMethod("external")
+	beforeDetectionFinishes(t, c, func() error {
+		InitAsync(External)
+		return nil
+	})
+	waitFor(t, c.started, "clipboard detection")
+}
+
+func TestInitAsyncPreservesLaterMethod(t *testing.T) {
+	for _, method := range []string{"terminal", "internal"} {
+		t.Run(method, func(t *testing.T) {
+			c := setupClipboard(t)
+			c.err = errors.New("clipboard unavailable")
+			startBlockedDetection(t, c)
+			selected := SetMethod(method)
+			if err := Initialize(selected); err != nil {
+				t.Fatal(err)
+			}
+			c.finish()
+			waitFor(t, external.done, "failed detection")
+			if CurrentMethod != selected {
+				t.Fatalf("detection changed method to %v; want %v", CurrentMethod, selected)
+			}
+		})
+	}
+}
+
+func checkRegister(r Register) error {
+	if err := Write("clipboard text", r); err != nil {
+		return err
+	}
+	if text, err := Read(r); err != nil || text != "clipboard text" {
+		return fmt.Errorf("Read(%d) = %q, %v", r, text, err)
+	}
+	for i, text := range []string{"first", "second"} {
+		if err := WriteMulti(text, r, i, 2); err != nil {
+			return err
+		}
+	}
+	for i, want := range []string{"first", "second"} {
+		if text, err := ReadMulti(r, i, 2); err != nil || text != want {
+			return fmt.Errorf("ReadMulti(%d, %d) = %q, %v; want %q", r, i, text, err, want)
+		}
+	}
+	return nil
+}
+
+func TestLocalRegistersDoNotWaitForDetection(t *testing.T) {
+	c := setupClipboard(t)
+	SetMethod("internal")
+	// Internal storage is also available before startup initializes anything.
+	beforeDetectionFinishes(t, c, func() error { return checkRegister(ClipboardReg) })
+	startBlockedDetection(t, c)
+	for _, method := range []string{"external", "terminal", "internal"} {
+		SetMethod(method)
+		for _, r := range []Register{0, 7, -3} {
+			beforeDetectionFinishes(t, c, func() error { return checkRegister(r) })
+		}
+	}
+	for _, r := range []Register{ClipboardReg, PrimaryReg} {
+		beforeDetectionFinishes(t, c, func() error { return checkRegister(r) })
+	}
+}
+
+type clipboardScreen struct {
+	tcell.Screen
+	text map[string]string
+}
+
+func (s *clipboardScreen) SetClipboard(text, reg string) error {
+	s.text[reg] = text
+	return nil
+}
+
+func (s *clipboardScreen) GetClipboard(reg string) error {
+	screen.Events <- tcell.NewEventPaste(s.text[reg], "")
+	return nil
+}
+
+func TestTerminalClipboardDoesNotWaitForDetection(t *testing.T) {
+	c := setupClipboard(t)
+	startBlockedDetection(t, c)
+	savedScreen, savedEvents := screen.Screen, screen.Events
+	s := &clipboardScreen{text: make(map[string]string)}
+	screen.Screen = s
+	screen.Events = make(chan tcell.Event, 1)
+	t.Cleanup(func() { screen.Screen, screen.Events = savedScreen, savedEvents })
+	SetMethod("terminal")
+	beforeDetectionFinishes(t, c, func() error {
+		for _, r := range []Register{ClipboardReg, PrimaryReg} {
+			if err := Write("terminal text", r); err != nil {
+				return err
+			}
+		}
+		s.text["clipboard"], s.text["primary"] = "terminal paste", "primary paste"
+		for r, want := range map[Register]string{ClipboardReg: "terminal paste", PrimaryReg: "primary paste"} {
+			if text, err := Read(r); err != nil || text != want {
+				return fmt.Errorf("terminal Read(%d) = %q, %v; want %q", r, text, err, want)
+			}
+		}
+		return nil
+	})
+	if s.text["c"] != "terminal text" || s.text["p"] != "terminal text" {
+		t.Fatalf("terminal writes = %v", s.text)
+	}
+}
+
+func TestExternalClipboardWaitsForDetection(t *testing.T) {
+	readText := func(text string, err error, want string) error {
+		if err != nil || text != want {
+			return fmt.Errorf("read = %q, %v; want %q", text, err, want)
+		}
+		return nil
+	}
+	operations := []struct {
+		name string
+		run  func(Register) error
+		want string
+	}{
+		{"read", func(r Register) error {
+			text, err := Read(r)
+			return readText(text, err, "firstsecond")
+		}, "firstsecond"},
+		{"write", func(r Register) error { return Write("written", r) }, "written"},
+		{"read multi", func(r Register) error {
+			text, err := ReadMulti(r, 0, 2)
+			return readText(text, err, "first")
+		}, "firstsecond"},
+		{"write multi", func(r Register) error { return WriteMulti("updated", r, 0, 2) }, "updatedsecond"},
+	}
+	for _, r := range []Register{ClipboardReg, PrimaryReg} {
+		for _, operation := range operations {
+			t.Run(fmt.Sprintf("%d/%s", r, operation.name), func(t *testing.T) {
+				c := setupClipboard(t)
+				reg := clipper.RegClipboard
+				if r == PrimaryReg {
+					reg = clipper.RegPrimary
+				}
+				c.text[reg] = []byte("firstsecond")
+				multi.writeText("first", r, 0, 2)
+				multi.writeText("second", r, 1, 2)
+				startBlockedDetection(t, c)
+				// Initializing another method must not mark the external probe ready.
+				if err := Initialize(SetMethod("terminal")); err != nil {
+					t.Fatal(err)
+				}
+				SetMethod("external")
+				done := make(chan error, 1)
+				go func() { done <- operation.run(r) }()
+				select {
+				case err := <-done:
+					t.Fatalf("external clipboard operation finished before detection: %v", err)
+				case <-time.After(20 * time.Millisecond):
+				}
+				c.finish()
+				select {
+				case err := <-done:
+					if err != nil {
+						t.Fatal(err)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("external clipboard operation did not finish")
+				}
+				if string(c.text[reg]) != operation.want {
+					t.Fatalf("external register %s = %q", reg, c.text[reg])
+				}
+			})
+		}
+	}
+}
+
+func TestPendingDetectionIsReused(t *testing.T) {
+	c := setupClipboard(t)
+	startBlockedDetection(t, c)
+	pending := external
+	for _, refresh := range []bool{false, true} {
+		if d := detect(refresh); d != pending {
+			t.Fatal("a new probe replaced detection that was still in progress")
+		}
+	}
+}
+
+func TestFailedDetectionFallsBackAndCanBeRetried(t *testing.T) {
+	c := setupClipboard(t)
+	c.err = errors.New("clipboard unavailable")
+	startBlockedDetection(t, c)
+	c.finish()
+	waitFor(t, external.done, "failed detection")
+	for _, r := range []Register{ClipboardReg, PrimaryReg} {
+		if err := checkRegister(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Explicit initialization can discover a backend installed after startup.
+	c.err = nil
+	if err := Initialize(External); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRegister(ClipboardReg); err != nil {
+		t.Fatal(err)
+	}
+	if string(c.text[clipper.RegClipboard]) != "firstsecond" {
+		t.Fatal("retry did not use the external clipboard")
+	}
+}
+
+func TestInitializeRefreshesCompletedDetection(t *testing.T) {
+	c := setupClipboard(t)
+	c.finish()
+	SetMethod("external")
+	if err := Initialize(External); err != nil {
+		t.Fatal(err)
+	}
+	// Replace the available provider. Ordinary operations keep their backend,
+	// but explicitly selecting external again must discover the replacement.
+	replacement := &controlledClipboard{
+		started: make(chan struct{}, 1), release: c.release,
+		text: map[string][]byte{clipper.RegClipboard: []byte("replacement")},
+	}
+	clipper.Clipboards = []clipper.Clipboard{replacement}
+	if err := checkRegister(ClipboardReg); err != nil {
+		t.Fatal(err)
+	}
+	if string(replacement.text[clipper.RegClipboard]) != "replacement" {
+		t.Fatal("ordinary clipboard operations re-detected the backend")
+	}
+	if err := Initialize(External); err != nil {
+		t.Fatal(err)
+	}
+	if text, err := Read(ClipboardReg); err != nil || text != "replacement" {
+		t.Fatalf("refreshed clipboard = %q, %v", text, err)
+	}
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -38,7 +38,7 @@ func (c *controlledClipboard) WriteAll(reg string, text []byte) error {
 func setupClipboard(t *testing.T) *controlledClipboard {
 	t.Helper()
 	t.Setenv("PATH", t.TempDir())
-	savedClips, savedExternal, savedMethod := clipper.Clipboards, external, CurrentMethod
+	savedClips, savedClipboard, savedMethod := clipper.Clipboards, clipboard, CurrentMethod
 	savedInternal, savedMulti := internal, multi
 	c := &controlledClipboard{
 		started: make(chan struct{}, 10),
@@ -46,15 +46,15 @@ func setupClipboard(t *testing.T) *controlledClipboard {
 		text:    make(map[string][]byte),
 	}
 	clipper.Clipboards = []clipper.Clipboard{c}
-	external = nil
+	clipboard = nil
 	internal = make(internalClipboard)
 	multi = make(multiClipboard)
 	t.Cleanup(func() {
 		c.finish()
-		if external != nil {
-			waitFor(t, external.done, "clipboard cleanup")
+		if clipboard != nil {
+			clipboard.Init()
 		}
-		clipper.Clipboards, external, CurrentMethod = savedClips, savedExternal, savedMethod
+		clipper.Clipboards, clipboard, CurrentMethod = savedClips, savedClipboard, savedMethod
 		internal, multi = savedInternal, savedMulti
 	})
 	return c
@@ -74,6 +74,22 @@ func waitFor(t *testing.T, ch <-chan struct{}, operation string) {
 	case <-ch:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+func TestInitializeFailureUsesInternalClipboard(t *testing.T) {
+	c := setupClipboard(t)
+	c.err = errors.New("clipboard unavailable")
+	c.finish()
+	SetMethod("external")
+	if err := Initialize(External); err == nil {
+		t.Fatal("external initialization should fail")
+	}
+	if CurrentMethod != Internal {
+		t.Fatalf("failed initialization left method %v; want Internal", CurrentMethod)
+	}
+	if err := checkRegister(ClipboardReg); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -145,7 +161,7 @@ func TestInitAsyncPreservesLaterMethod(t *testing.T) {
 				t.Fatal(err)
 			}
 			c.finish()
-			waitFor(t, external.done, "failed detection")
+			clipboard.Init()
 			if CurrentMethod != selected {
 				t.Fatalf("detection changed method to %v; want %v", CurrentMethod, selected)
 			}
@@ -300,11 +316,15 @@ func TestExternalClipboardWaitsForDetection(t *testing.T) {
 func TestPendingDetectionIsReused(t *testing.T) {
 	c := setupClipboard(t)
 	startBlockedDetection(t, c)
-	pending := external
-	for _, refresh := range []bool{false, true} {
-		if d := detect(refresh); d != pending {
-			t.Fatal("a new probe replaced detection that was still in progress")
-		}
+	InitAsync(External)
+	c.finish()
+	if err := clipboard.Init(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-c.started:
+		t.Fatal("repeated startup initialization probed the backend again")
+	default:
 	}
 }
 
@@ -313,14 +333,18 @@ func TestFailedDetectionFallsBackAndCanBeRetried(t *testing.T) {
 	c.err = errors.New("clipboard unavailable")
 	startBlockedDetection(t, c)
 	c.finish()
-	waitFor(t, external.done, "failed detection")
+	clipboard.Init()
 	for _, r := range []Register{ClipboardReg, PrimaryReg} {
 		if err := checkRegister(r); err != nil {
 			t.Fatal(err)
 		}
 	}
+	if CurrentMethod != Internal {
+		t.Fatalf("failed detection left method %v; want Internal", CurrentMethod)
+	}
 	// Explicit initialization can discover a backend installed after startup.
 	c.err = nil
+	SetMethod("external")
 	if err := Initialize(External); err != nil {
 		t.Fatal(err)
 	}

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -60,7 +60,9 @@ Here are the available options:
        or wl-clipboard on Linux, pbcopy/pbpaste on MacOS, and system calls on
        Windows. On Linux, if you do not have one of the tools installed, or if
        they are not working, micro will throw an error and use an internal
-       clipboard.
+       clipboard. Detection runs in the background during startup. The first
+       system clipboard operation waits if detection has not finished yet;
+       internal registers remain available while it runs.
     * `terminal`: accesses the clipboard via your terminal emulator. Note that
        there is limited support among terminal emulators for this feature
        (called OSC 52). Terminals that are known to work are Kitty (enable

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -58,11 +58,11 @@ Here are the available options:
    Possible values are:
     * `external`: accesses clipboard via an external tool, such as xclip/xsel
        or wl-clipboard on Linux, pbcopy/pbpaste on MacOS, and system calls on
-       Windows. On Linux, if you do not have one of the tools installed, or if
-       they are not working, micro will throw an error and use an internal
-       clipboard. Detection runs in the background during startup. The first
-       system clipboard operation waits if detection has not finished yet;
-       internal registers remain available while it runs.
+       Windows. Detection runs in the background during startup. The first
+       system clipboard operation waits if detection has not finished yet.
+       If no tool works, micro logs the detection error on that first use and
+       switches to an internal clipboard. Internal registers remain available
+       while detection runs.
     * `terminal`: accesses the clipboard via your terminal emulator. Note that
        there is limited support among terminal emulators for this feature
        (called OSC 52). Terminals that are known to work are Kitty (enable


### PR DESCRIPTION
Slow PATH searches and clipboard-tool probes can delay micro's first frame in WSL. This starts detection through `clipper.GetClipboardAsync`, with the worker and result synchronization owned by clipper. Micro uses the existing Clipboard interface and handles its own mode selection and internal fallback.

Depends on https://github.com/zyedidia/clipper/pull/6. This branch pins the published fork revision `3095b365e472` through a documented `go.mod` replacement so reviewers and CI can build it without a local workspace. Replace that pin with an upstream clipper revision before merging.

The custom `micro-clip` command keeps its priority. Internal registers, terminal clipboard access, and their multi-cursor operations remain available during detection. Failed startup detection is logged on first external clipboard use and falls back to internal storage. Explicit initialization refreshes detection and restores internal storage on failure without overwriting a later method selection.

README guidance covers Windows Terminal's OSC 52 option, and option help explains the remaining wait on first system clipboard use.

Closes #4209.

## Validation

- Full micro test suites pass on Windows and natively in Ubuntu WSL with `GOWORK=off` and the published dependency pin.
- Micro's clipboard package and clipper pass `go test -race -count=20` on Windows and Linux.
- All 30 existing buffer benchmarks complete on each platform with `go test -run '^$' -bench . -benchmem -count=1 ./...`.
- Windows and Linux editor builds pass. Go formatting and whitespace checks pass.
- A controlled PTY test confirms that upstream waits for a blocked custom probe before drawing, while the previous and revised PR versions display the buffer during detection and paste correctly once it finishes.
- The nonblocking-constructor and explicit-initialization fallback regressions were observed failing before their fixes.

The broader Windows `cmd/micro` race test still reports buffer hashing/highlighting races, and full micro vet reports existing warnings. Both reproduce on unchanged upstream `393cf248`. Clipper's Windows vet warning at `winapi.go:90` also reproduces in unchanged v0.1.1; its other vet checks and Linux vet pass.

## Startup measurements

Rerun on September 8 with Go 1.27.1. The three Linux binaries use the same `-trimpath -buildvcs=false` build flags with CGO disabled: upstream `393cf248`, the previous PR revision `33548404`, and this revision using clipper `3095b365e472`.

The runner measures process launch to the first buffer-content output in a controlling PTY. WSL is already running; settings and input files are identical; one warmup per build/case is excluded; and build order rotates evenly. No tests or builds ran alongside the timing samples. These are real clipboard probes, without artificial delays. PATH has 53 entries, including 44 Windows paths, and this environment selects `xclip`, not the reporter's PowerShell backend.

| Executable location / clipboard | Runs per build | Upstream median | Previous PR median | Revised median |
| --- | ---: | ---: | ---: | ---: |
| WSL Linux filesystem / external | 12 | 132.76 ms | 11.70 ms | 11.96 ms |
| WSL Linux filesystem / terminal | 9 | 11.09 ms | 10.50 ms | 10.21 ms |
| Windows-mounted `/mnt/c` / external | 12 | 416.06 ms | 297.00 ms | 296.16 ms |
| Windows-mounted `/mnt/c` / terminal | 9 | 275.94 ms | 291.86 ms | 291.11 ms |

The revised Linux-filesystem/external runs ranged from 9.86 to 16.22 ms, compared with 9.57 to 24.09 ms for the previous PR and 100.06 to 180.74 ms for upstream. Moving detection into clipper shows no meaningful startup slowdown in this sample. The roughly 91% lower median applies to this measured case. Mounted-filesystem results are noisy with overlapping ranges, and the first external clipboard operation can still wait for detection.
